### PR TITLE
Add piping from stdin to stdout with a -

### DIFF
--- a/black.py
+++ b/black.py
@@ -175,7 +175,8 @@ def format_stdin_to_stdout(line_length: int, fast: bool) -> bool:
     except NothingChanged:
         return False
 
-    sys.stdout.write(contents)
+    finally:
+        sys.stdout.write(contents)
     return True
 
 

--- a/black.py
+++ b/black.py
@@ -3,13 +3,22 @@ import asyncio
 from asyncio.base_events import BaseEventLoop
 from concurrent.futures import Executor, ProcessPoolExecutor
 from functools import partial
-import io
 import keyword
 import os
 from pathlib import Path
 import tokenize
 from typing import (
-    Dict, Generic, Iterable, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    TextIO,
+    Tuple,
+    TypeVar,
+    Union,
 )
 import sys
 
@@ -174,21 +183,21 @@ def format_stdin_to_stdout(line_length: int, fast: bool) -> bool:
 
 
 def format_file(
-    src_buffer: Type[io.TextIOBase], line_length: int, fast: bool
+    src: TextIO, line_length: int, fast: bool
 ) -> Tuple[FileContent, Encoding]:
     """Reformats a file and returns its contents and encoding."""
-    src_contents = src_buffer.read()
+    src_contents = src.read()
     if src_contents.strip() == '':
-        raise NothingChanged(src_buffer.name)
+        raise NothingChanged(src.name)
 
     dst_contents = format_str(src_contents, line_length=line_length)
     if src_contents == dst_contents:
-        raise NothingChanged(src_buffer.name)
+        raise NothingChanged(src.name)
 
     if not fast:
         assert_equivalent(src_contents, dst_contents)
         assert_stable(src_contents, dst_contents, line_length=line_length)
-    return dst_contents, src_buffer.encoding
+    return dst_contents, src.encoding
 
 
 def format_str(src_contents: str, line_length: int) -> FileContent:

--- a/black.py
+++ b/black.py
@@ -9,19 +9,8 @@ from pathlib import Path
 import tokenize
 import sys
 from typing import (
-    Dict,
-    Generic,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    TextIO,
-    Tuple,
-    TypeVar,
-    Union,
+    Dict, Generic, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar, Union
 )
-import sys
 
 from attr import dataclass, Factory
 import click

--- a/black.py
+++ b/black.py
@@ -83,27 +83,24 @@ class CannotSplit(Exception):
 def main(ctx: click.Context, line_length: int, fast: bool, src: List[str]) -> None:
     """The uncompromising code formatter."""
     sources: List[Path] = []
-    if len(src) == 1 and src[0] == '-':
-        sources.append(Path('-'))
-    else:
-        for s in src:
-            p = Path(s)
-            if p.is_dir():
-                sources.extend(gen_python_files_in_dir(p))
-            elif p.is_file():
-                # if a file was explicitly given, we don't care about its extension
-                sources.append(p)
-            elif s == '-':
-                err('Cannot format both stdin and other paths')
-            else:
-                err(f'invalid path: {s}')
+    for s in src:
+        p = Path(s)
+        if p.is_dir():
+            sources.extend(gen_python_files_in_dir(p))
+        elif p.is_file():
+            # if a file was explicitly given, we don't care about its extension
+            sources.append(p)
+        elif s == '-':
+            sources.append(Path('-'))
+        else:
+            err(f'invalid path: {s}')
     if len(sources) == 0:
         ctx.exit(0)
     elif len(sources) == 1:
         p = sources[0]
         report = Report()
         try:
-            if str(p) == '-':
+            if not p.is_file() and str(p) == '-':
                 changed = format_stdin_to_stdout(line_length=line_length, fast=fast)
             else:
                 changed = format_file_in_place(p, line_length=line_length, fast=fast)

--- a/black.py
+++ b/black.py
@@ -177,14 +177,14 @@ def format_file_in_place(
     with tokenize.open(src) as src_buffer:
         src_contents = src_buffer.read()
     try:
-        contents, encoding = format_file_contents(
+        contents = format_file_contents(
             src_contents, line_length=line_length, fast=fast
         )
     except NothingChanged:
         return False
 
     if write_back:
-        with open(src, "w", encoding=encoding) as f:
+        with open(src, "w", encoding=src_buffer.encoding) as f:
             f.write(contents)
     return True
 
@@ -193,7 +193,7 @@ def format_stdin_to_stdout(line_length: int, fast: bool) -> bool:
     """Format file on stdin and pipe output to stdout. Return True if changed."""
     contents = sys.stdin.read()
     try:
-        contents, _ = format_file_contents(contents, line_length=line_length, fast=fast)
+        contents = format_file_contents(contents, line_length=line_length, fast=fast)
         return True
 
     except NothingChanged:
@@ -205,19 +205,19 @@ def format_stdin_to_stdout(line_length: int, fast: bool) -> bool:
 
 def format_file_contents(
     src_contents: str, line_length: int, fast: bool
-) -> Tuple[FileContent, Encoding]:
+) -> FileContent:
     """Reformats a file and returns its contents and encoding."""
     if src_contents.strip() == '':
-        raise NothingChanged(src.name)
+        raise NothingChanged
 
     dst_contents = format_str(src_contents, line_length=line_length)
     if src_contents == dst_contents:
-        raise NothingChanged(src.name)
+        raise NothingChanged
 
     if not fast:
         assert_equivalent(src_contents, dst_contents)
         assert_stable(src_contents, dst_contents, line_length=line_length)
-    return dst_contents, src.encoding
+    return dst_contents
 
 
 def format_str(src_contents: str, line_length: int) -> FileContent:

--- a/black.py
+++ b/black.py
@@ -174,11 +174,12 @@ def format_file_in_place(
     src: Path, line_length: int, fast: bool, write_back: bool = False
 ) -> bool:
     """Format the file and rewrite if changed. Return True if changed."""
+    with tokenize.open(src) as src_buffer:
+        src_contents = src_buffer.read()
     try:
-        with tokenize.open(src) as src_buffer:
-            contents, encoding = format_file(
-                src_buffer, line_length=line_length, fast=fast
-            )
+        contents, encoding = format_file_contents(
+            src_contents, line_length=line_length, fast=fast
+        )
     except NothingChanged:
         return False
 
@@ -190,21 +191,22 @@ def format_file_in_place(
 
 def format_stdin_to_stdout(line_length: int, fast: bool) -> bool:
     """Format file on stdin and pipe output to stdout. Return True if changed."""
+    contents = sys.stdin.read()
     try:
-        contents, _ = format_file(sys.stdin, line_length=line_length, fast=fast)
+        contents, _ = format_file_contents(contents, line_length=line_length, fast=fast)
+        return True
+
     except NothingChanged:
         return False
 
     finally:
         sys.stdout.write(contents)
-    return True
 
 
-def format_file(
-    src: TextIO, line_length: int, fast: bool
+def format_file_contents(
+    src_contents: str, line_length: int, fast: bool
 ) -> Tuple[FileContent, Encoding]:
     """Reformats a file and returns its contents and encoding."""
-    src_contents = src.read()
     if src_contents.strip() == '':
         raise NothingChanged(src.name)
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from functools import partial
 from pathlib import Path
+import tokenize
 from typing import List, Tuple
 import unittest
 from unittest.mock import patch
@@ -10,10 +11,14 @@ from click import unstyle
 import black
 
 ll = 88
-ff = partial(black.format_file, line_length=ll, fast=True)
 fs = partial(black.format_str, line_length=ll)
 THIS_FILE = Path(__file__)
 THIS_DIR = THIS_FILE.parent
+
+
+def ff(file_):
+    with tokenize.open(file_) as buf:
+        black.format_file(buf, line_length=ll, fast=True)
 
 
 def dump_to_stderr(*output: str) -> str:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -4,7 +4,7 @@ from io import StringIO
 from pathlib import Path
 import sys
 import tokenize
-from typing import Any, List, Tuple, TextIO
+from typing import Any, List, Tuple
 import unittest
 from unittest.mock import patch
 
@@ -18,7 +18,7 @@ THIS_FILE = Path(__file__)
 THIS_DIR = THIS_FILE.parent
 
 
-def ff(file: TextIO) -> None:
+def ff(file: Path) -> None:
     with tokenize.open(file) as buf:
         black.format_file(buf, line_length=ll, fast=True)
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -3,7 +3,6 @@ from functools import partial
 from io import StringIO
 from pathlib import Path
 import sys
-import tokenize
 from typing import Any, List, Tuple
 import unittest
 from unittest.mock import patch
@@ -13,14 +12,10 @@ from click import unstyle
 import black
 
 ll = 88
+ff = partial(black.format_file_in_place, line_length=ll, fast=True)
 fs = partial(black.format_str, line_length=ll)
 THIS_FILE = Path(__file__)
 THIS_DIR = THIS_FILE.parent
-
-
-def ff(file: Path) -> None:
-    with tokenize.open(file) as buf:
-        black.format_file(buf, line_length=ll, fast=True)
 
 
 def dump_to_stderr(*output: str) -> str:
@@ -77,8 +72,7 @@ class BlackTestCase(unittest.TestCase):
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, line_length=ll)
-        with self.assertRaises(black.NothingChanged):
-            ff(THIS_FILE)
+        self.assertFalse(ff(THIS_FILE))
 
     @patch("black.dump_to_file", dump_to_stderr)
     def test_black(self) -> None:
@@ -87,8 +81,7 @@ class BlackTestCase(unittest.TestCase):
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, line_length=ll)
-        with self.assertRaises(black.NothingChanged):
-            ff(THIS_FILE)
+        self.assertFalse(ff(THIS_DIR / '..' / 'black.py'))
 
     def test_piping(self) -> None:
         source, expected = read_data('../black')
@@ -114,8 +107,7 @@ class BlackTestCase(unittest.TestCase):
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, line_length=ll)
-        with self.assertRaises(black.NothingChanged):
-            ff(THIS_FILE)
+        self.assertFalse(ff(THIS_DIR / '..' / 'setup.py'))
 
     @patch("black.dump_to_file", dump_to_stderr)
     def test_function(self) -> None:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -90,10 +90,8 @@ class BlackTestCase(unittest.TestCase):
             sys.stdin, sys.stdout = StringIO(source), StringIO()
             sys.stdin.name = '<stdin>'
             black.format_stdin_to_stdout(line_length=ll, fast=True)
-            black.err(f'%%%%% {sys.stdout.tell()}')
             sys.stdout.seek(0)
-            black.err(f'%%%%% {len(sys.stdout)}')
-            actual = sys.stdout.readlines()
+            actual = sys.stdout.read()
         finally:
             sys.stdin, sys.stdout = hold_stdin, hold_stdout
         self.assertFormatEqual(expected, actual)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -16,8 +16,8 @@ THIS_FILE = Path(__file__)
 THIS_DIR = THIS_FILE.parent
 
 
-def ff(file_):
-    with tokenize.open(file_) as buf:
+def ff(file):
+    with tokenize.open(file) as buf:
         black.format_file(buf, line_length=ll, fast=True)
 
 


### PR DESCRIPTION
Being able to format code by piping it through the formatter makes it much easier to integrate with tools like google/vim-codefmt or Chiel92/vim-autoformat.

My Python is okay-but-not-fantastic and I'm not toally happy with the way I've modified main(), and am not sure how best to test this. Happy to put the work into improving the PR, though.