### PR TITLE
Line breaks before logical operators

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 # Keep in sync with setup.cfg which is used for source packages.
 
 [flake8]
-ignore = E266, E501
+ignore = E266, E501, W503
 max-line-length = 80
 max-complexity = 15
 select = B,C,E,F,W,T4,B9

--- a/tests/comments2.py
+++ b/tests/comments2.py
@@ -35,12 +35,12 @@ def inline_comments_in_brackets_ruin_everything():
             body,
             parameters.children[-1],  # )2
         ]
-    if (self._proc is not None and
+    if (self._proc is not None
             # has the child process finished?
-            self._returncode is None and
+            and self._returncode is None
             # the child process has finished, but the
             # transport hasn't been notified yet?
-            self._proc.poll() is None):
+            and self._proc.poll() is None):
         pass
     short = [
      # one
@@ -137,12 +137,12 @@ def inline_comments_in_brackets_ruin_everything():
             parameters.children[-1],  # )2
         ]
     if (
-        self._proc is not None and
+        self._proc is not None
         # has the child process finished?
-        self._returncode is None and
+        and self._returncode is None
         # the child process has finished, but the
         # transport hasn't been notified yet?
-        self._proc.poll() is None
+        and self._proc.poll() is None
     ):
         pass
     short = [

--- a/tests/expression.py
+++ b/tests/expression.py
@@ -118,6 +118,12 @@ def gen():
 async def f():
     await some.complicated[0].call(with_args=(True or (1 is not 1)))
 
+if (
+    threading.current_thread() != threading.main_thread() and
+    threading.current_thread() != threading.main_thread() or
+    signal.getsignal(signal.SIGINT) != signal.default_int_handler
+):
+    return True
 
 # output
 
@@ -261,3 +267,11 @@ def gen():
 
 async def f():
     await some.complicated[0].call(with_args=(True or (1 is not 1)))
+
+
+if (
+    threading.current_thread() != threading.main_thread()
+    and threading.current_thread() != threading.main_thread()
+    or signal.getsignal(signal.SIGINT) != signal.default_int_handler
+):
+    return True


### PR DESCRIPTION
This addresses https://github.com/ambv/black/issues/21 where the PEP 8 guidelines state that it's preferred for lines to be broken before a logical operator, rather than afterwards. 

However, flake8 yells at me with ``W503 line break before binary operator``, so :sweat_smile: 