### PR TITLE
Fix --check with multiple files

### DIFF
--- a/black.py
+++ b/black.py
@@ -181,7 +181,7 @@ async def schedule_formatting(
     }
     await asyncio.wait(tasks.values())
     cancelled = []
-    report = Report()
+    report = Report(check=not write_back)
     for src, task in tasks.items():
         if not task.done():
             report.failed(src, 'timed out, cancelling')


### PR DESCRIPTION
Passing multiple files with --check would previously result in the report being printed as if the files had been written to:

```console
$ black --check foo.py 
would reformat foo.py
$ black --check foo.py bar.py 
reformatted foo.py
bar.py already well formatted, good job.
All done! ✨ 🍰 ✨
1 file reformatted, 1 file left unchanged.
```

Now the output is correct when multiple files are checked.