### PR TITLE
use conda for readthedocs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: black_docs
 channels:
   - conda-forge
 dependencies:
-- python==3.6
+- python>=3.6
 - Sphinx==1.7.2
 - pip:
   - recommonmark==0.4.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,9 @@
+name: black_docs
+channels:
+  - conda-forge
+dependencies:
+- python==3.6
+- Sphinx==1.7.2
+- pip:
+  - recommonmark==0.4.0
+  - git+https://git@github.com/ambv/black.git

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,6 @@
+name: jupyterhub
+type: sphinx
+conda:
+    file: docs/environment.yml
+python:
+  version: 3


### PR DESCRIPTION
This PR adds 2 yaml files so that RTD will use conda to build the docs environment. 

[Rendered test docs on RTD](http://test-black.readthedocs.io/en/doc-conda/reference/reference_summary.html)