### PR TITLE
Lines now break before all delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,9 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
 
 ### 18.3a5 (unreleased)
 
+* add line breaks before all delimiters, except in cases like commas, to better
+  comply with PEP8 (#73)
+
 * fixed handling of standalone comments within nested bracketed
   expressions; Black will no longer produce super long lines or put all
   standalone comments at the end of the expression (#22)
@@ -504,5 +507,5 @@ Multiple contributions by:
 * [Daniel M. Capella](mailto:polycitizen@gmail.com)
 * [Eli Treuherz](mailto:eli.treuherz@cgi.com)
 * Hugo van Kemenade
-* [Mika⠙](mailto:mail@autophagy.io)
+* [Mika Naylor](mailto:mail@autophagy.io)
 * [Osaetin Daniel](mailto:osaetindaniel@gmail.com)

--- a/docs/reference/reference_functions.rst
+++ b/docs/reference/reference_functions.rst
@@ -12,6 +12,10 @@ Assertions and checks
 
 .. autofunction:: black.assert_stable
 
+.. autofunction:: black.is_split_after_delimiter
+
+.. autofunction:: black.is_split_before_delimiter
+
 .. autofunction:: black.is_delimiter
 
 .. autofunction:: black.is_import

--- a/tests/expression.py
+++ b/tests/expression.py
@@ -149,6 +149,36 @@ if (
     signal.getsignal(signal.SIGINT) != signal.default_int_handler
 ):
     return True
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
 last_call()
 # standalone comment at ENDMARKER
 
@@ -326,6 +356,42 @@ if (
     threading.current_thread() != threading.main_thread()
     and threading.current_thread() != threading.main_thread()
     or signal.getsignal(signal.SIGINT) != signal.default_int_handler
+):
+    return True
+
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    * aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    return True
+
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    / aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ):
     return True
 

--- a/tests/import_spacing.py
+++ b/tests/import_spacing.py
@@ -21,16 +21,16 @@ from .a.b.c.subprocess import *
 from . import tasks
 
 __all__ = (
-    base_events.__all__ +
-    coroutines.__all__ +
-    events.__all__ +
-    futures.__all__ +
-    locks.__all__ +
-    protocols.__all__ +
-    runners.__all__ +
-    queues.__all__ +
-    streams.__all__ +
-    tasks.__all__
+    base_events.__all__
+    + coroutines.__all__
+    + events.__all__
+    + futures.__all__
+    + locks.__all__
+    + protocols.__all__
+    + runners.__all__
+    + queues.__all__
+    + streams.__all__
+    + tasks.__all__
 )
 
 
@@ -60,14 +60,14 @@ from .a.b.c.subprocess import *
 from . import tasks
 
 __all__ = (
-    base_events.__all__ +
-    coroutines.__all__ +
-    events.__all__ +
-    futures.__all__ +
-    locks.__all__ +
-    protocols.__all__ +
-    runners.__all__ +
-    queues.__all__ +
-    streams.__all__ +
-    tasks.__all__
+    base_events.__all__
+    + coroutines.__all__
+    + events.__all__
+    + futures.__all__
+    + locks.__all__
+    + protocols.__all__
+    + runners.__all__
+    + queues.__all__
+    + streams.__all__
+    + tasks.__all__
 )


### PR DESCRIPTION
The default behaviour is that now all lines break *before* delimiters,
instead of afterwards. The special cases for this are commas and
behaviour around args.

Resolves #73 

I've also added my full name to the contributors list :wink: