### PR TITLE
Use IntEnum instead of Enum

### DIFF
--- a/black.py
+++ b/black.py
@@ -3,7 +3,7 @@
 import asyncio
 from asyncio.base_events import BaseEventLoop
 from concurrent.futures import Executor, ProcessPoolExecutor
-from enum import Enum
+from enum import IntEnum
 from functools import partial, wraps
 import keyword
 import logging
@@ -95,7 +95,7 @@ class FormatOff(FormatError):
     """Found a comment like `# fmt: off` in the file."""
 
 
-class WriteBack(Enum):
+class WriteBack(IntEnum):
     NO = 0
     YES = 1
     DIFF = 2


### PR DESCRIPTION
The code is failing to detect properly that we are running in check mode because the `Enum` class is not being used properly. It's defined as:

```
class WriteBack(Enum):
    NO = 0
    YES = 1
    DIFF = 2
```

And then in the code you can see this:

```
    report = Report(check=not write_back)
```

However, that code always yields `False`:

```
>>> class WriteBack(Enum):
...     NO = 0
...     YES = 1
...     DIFF = 2
...
>>> not WriteBack.NO
False
>>> not WriteBack.YES
False
>>> not WriteBack.DIFF
False
```

This issue basically causes `black --check .` to always return 0.

Using `IntEnum` instead causes the logic to work as expected:

```
>>> class WriteBack(IntEnum):
...     NO = 0
...     YES = 1
...     DIFF = 2
...
>>> not WriteBack.NO
True
>>> not WriteBack.YES
False
>>> not WriteBack.DIFF
False
```
