### PR TITLE
Handle backslashes in raw strings while normalizing

### DIFF
--- a/tests/string_quotes.py
+++ b/tests/string_quotes.py
@@ -15,6 +15,9 @@ f'''This is a triple-quoted {f}-string'''
 f'MOAR {" ".join([])}'
 f"MOAR {' '.join([])}"
 r"raw string ftw"
+r'Date d\'expiration:(.*)'
+r'Tricky "quote'
+r'Not-so-tricky \"quote'
 
 # output
 
@@ -35,3 +38,6 @@ f"""This is a triple-quoted {f}-string"""
 f'MOAR {" ".join([])}'
 f"MOAR {' '.join([])}"
 r"raw string ftw"
+r"Date d\'expiration:(.*)"
+r'Tricky "quote'
+r"Not-so-tricky \"quote"


### PR DESCRIPTION
In raw strings, a single backslash means a literal backslash. It is also used to escape quotes if it precedes them. This means it is impossible to change the quote type for strings that contain an unescaped version of the other quote type (see test cases).
Fixes #100