### PR TITLE
Open temporary files with utf-8 encoding

### DIFF
--- a/black.py
+++ b/black.py
@@ -2325,7 +2325,7 @@ def dump_to_file(*output: str) -> str:
     import tempfile
 
     with tempfile.NamedTemporaryFile(
-        mode="w", prefix="blk_", suffix=".log", delete=False
+        mode="w", prefix="blk_", suffix=".log", delete=False, encoding="utf-8"
     ) as f:
         for lines in output:
             f.write(lines)

--- a/black.py
+++ b/black.py
@@ -2325,7 +2325,7 @@ def dump_to_file(*output: str) -> str:
     import tempfile
 
     with tempfile.NamedTemporaryFile(
-        mode="w", prefix="blk_", suffix=".log", delete=False, encoding="utf-8"
+        mode="w", prefix="blk_", suffix=".log", delete=False, encoding="utf8"
     ) as f:
         for lines in output:
             f.write(lines)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -150,7 +150,7 @@ class BlackTestCase(unittest.TestCase):
         tmp_file = Path(black.dump_to_file(source))
         try:
             self.assertTrue(ff(tmp_file, write_back=black.WriteBack.YES))
-            with open(tmp_file) as f:
+            with open(tmp_file, encoding="utf-8") as f:
                 actual = f.read()
         finally:
             os.unlink(tmp_file)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -150,7 +150,7 @@ class BlackTestCase(unittest.TestCase):
         tmp_file = Path(black.dump_to_file(source))
         try:
             self.assertTrue(ff(tmp_file, write_back=black.WriteBack.YES))
-            with open(tmp_file, encoding="utf-8") as f:
+            with open(tmp_file, encoding="utf8") as f:
                 actual = f.read()
         finally:
             os.unlink(tmp_file)


### PR DESCRIPTION
This is not the default on Windows. Fixes #124 