### PR TITLE
fixed cache file location in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,9 +448,9 @@ location of the file depends on the black version and the system on which black
 is run. The file is non-portable. The standard location on common operating systems
 is:
 
-* Windows: `C:\\Users\<username>\AppData\Local\black\black\Cache\<version>\cache.pkl`
-* macOS: `/Users/<username>/Library/Caches/black/<version>/cache.pkl`
-* Linux: `/home/<username>/.cache/black/<version>/cache.pkl`
+* Windows: `C:\\Users\<username>\AppData\Local\black\black\Cache\<version>\cache.pickle`
+* macOS: `/Users/<username>/Library/Caches/black/<version>/cache.pickle`
+* Linux: `/home/<username>/.cache/black/<version>/cache.pickle`
 
 
 ## Testimonials


### PR DESCRIPTION
I just realized I never updated the paths to the pickle files for caching in the readme. Sorry about that.