### PR TITLE
Remove unnecessary shebang lines

### DIFF
--- a/black.py
+++ b/black.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import asyncio
 import pickle
 from asyncio.base_events import BaseEventLoop

--- a/blib2to3/pgen2/token.py
+++ b/blib2to3/pgen2/token.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python3
-
 """Token constants (from "token.h")."""
 
 #  Taken from Python (r53757) and modified to include some tokens


### PR DESCRIPTION
Since black.py is not marked as executable, the shebang in black.py serves
no purpose. black should be invoked through its entry point any way.

token.py is an internal module without a __name__ == '__main__' block or
other executable code. It contains just list of constants and small
helper functions.

Signed-off-by: Christian Heimes <christian@python.org>