### PR TITLE
Output something when no files are reformatted

### DIFF
--- a/black.py
+++ b/black.py
@@ -192,6 +192,7 @@ def main(
         write_back = WriteBack.YES
     report = Report(check=check, quiet=quiet)
     if len(sources) == 0:
+        out("No paths given. Nothing to do 😴")
         ctx.exit(0)
         return
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -636,6 +636,12 @@ class BlackTestCase(unittest.TestCase):
             )
             self.assertEqual(result.exit_code, 1)
 
+    def test_no_files(self) -> None:
+        with cache_dir():
+            # Without an argument, black exits with error code 0.
+            result = CliRunner().invoke(black.main, [])
+            self.assertEqual(result.exit_code, 0)
+
     def test_read_cache_line_lengths(self) -> None:
         with cache_dir() as workspace:
             path = (workspace / "file.py").resolve()


### PR DESCRIPTION
Just executing ``black`` without any argument does not print any message
to stdout or stderr. It's rather confusing, because the user doesn't
know what happened.

In ``len(sources) == 0`` case, black now prints ``No files
reformatted``.

Signed-off-by: Christian Heimes <christian@python.org>