### PR TITLE
Add more files/directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ _build
 .DS_Store
 .vscode
 docs/_static/pypi.svg
+.tox
+__pycache__
+black.egg-info


### PR DESCRIPTION
Ignore .tox, black.egg-info and __pycache__ directories.

Signed-off-by: Christian Heimes <christian@python.org>