### PR TITLE
Check for broken symlinks before checking file data

### DIFF
--- a/black.py
+++ b/black.py
@@ -2494,7 +2494,7 @@ def gen_python_files_in_dir(path: Path) -> Iterator[Path]:
 
             yield from gen_python_files_in_dir(child)
 
-        elif child.suffix in PYTHON_EXTENSIONS:
+        elif child.is_file() and child.suffix in PYTHON_EXTENSIONS:
             yield child
 
 

--- a/black.py
+++ b/black.py
@@ -2761,8 +2761,6 @@ def filter_cached(
     todo, done = [], []
     for src in sources:
         src = src.resolve()
-        if not src.exists():
-            continue
         if cache.get(src) != get_cache_info(src):
             todo.append(src)
         else:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -636,12 +636,9 @@ class BlackTestCase(unittest.TestCase):
             uncached.touch()
             cached.touch()
             cached_but_changed.touch()
-            symlink = path / "broken_link"
-            symlink.symlink_to("nonexistent")
-            broken_link = symlink.resolve()
             cache = {cached: black.get_cache_info(cached), cached_but_changed: (0.0, 0)}
             todo, done = black.filter_cached(
-                cache, [uncached, cached, cached_but_changed, broken_link]
+                cache, [uncached, cached, cached_but_changed]
             )
             self.assertEqual(todo, [uncached, cached_but_changed])
             self.assertEqual(done, [cached])

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -695,6 +695,13 @@ class BlackTestCase(unittest.TestCase):
             result = CliRunner().invoke(black.main, [])
             self.assertEqual(result.exit_code, 0)
 
+    def test_broken_symlink(self) -> None:
+        with cache_dir() as workspace:
+            symlink = workspace / "broken_link.py"
+            symlink.symlink_to("nonexistent.py")
+            result = CliRunner().invoke(black.main, [str(workspace.resolve())])
+            self.assertEqual(result.exit_code, 0)
+
     def test_read_cache_line_lengths(self) -> None:
         with cache_dir() as workspace:
             path = (workspace / "file.py").resolve()


### PR DESCRIPTION
New unit test fails without the check in the code, passed afterwards.