### PR TITLE
Skip symlink test if can't create one

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -731,7 +731,10 @@ class BlackTestCase(unittest.TestCase):
     def test_broken_symlink(self) -> None:
         with cache_dir() as workspace:
             symlink = workspace / "broken_link.py"
-            symlink.symlink_to("nonexistent.py")
+            try:
+                symlink.symlink_to("nonexistent.py")
+            except OSError as e:
+                self.skipTest(f"Can't create symlinks: {e}")
             result = CliRunner().invoke(black.main, [str(workspace.resolve())])
             self.assertEqual(result.exit_code, 0)
 


### PR DESCRIPTION
For some reason I get this in my windows environment:

```
ERROR: test_broken_symlink (__main__.BlackTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".\tests\test_black.py", line 734, in test_broken_symlink
    symlink.symlink_to("nonexistent.py")
  File "c:\program files (x86)\python36-32\Lib\pathlib.py", line 1325, in symlink_to
    self._accessor.symlink(target, self, target_is_directory)
  File "c:\program files (x86)\python36-32\Lib\pathlib.py", line 393, in wrapped
    return strfunc(str(pathobjA), str(pathobjB), *args)
OSError: symbolic link privilege not held
```

Looks like this works fine on appveyor though.