### PR TITLE
Preserve line endings when formatting a file in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,8 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
 * fixed stdin handling not working correctly if an old version of Click was
   used (#276)
 
+* *Black* now preserves line endings when formatting a file in place (#258)
+
 
 ### 18.5b1
 

--- a/black.py
+++ b/black.py
@@ -454,7 +454,9 @@ def format_file_in_place(
         return False
 
     if write_back == write_back.YES:
-        with open(src, "w", encoding=src_buffer.encoding) as f:
+        with open(src, encoding=src_buffer.encoding, newline="") as src_buffer:
+            newline = "\r\n" if "\r\n" in src_buffer.readline() else "\n"
+        with open(src, "w", encoding=src_buffer.encoding, newline=newline) as f:
             f.write(dst_contents)
     elif write_back == write_back.DIFF:
         src_name = f"{src}  (original)"
@@ -569,8 +571,7 @@ def lib2to3_parse(src_txt: str) -> Node:
     """Given a string with source, return the lib2to3 Node."""
     grammar = pygram.python_grammar_no_print_statement
     if src_txt[-1] != "\n":
-        nl = "\r\n" if "\r\n" in src_txt[:1024] else "\n"
-        src_txt += nl
+        src_txt += "\n"
     for grammar in GRAMMARS:
         drv = driver.Driver(grammar, pytree.convert)
         try:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -910,6 +910,18 @@ class BlackTestCase(unittest.TestCase):
             result = CliRunner().invoke(black.main, ["-", option, "**()(!!*)"])
             self.assertEqual(result.exit_code, 2)
 
+    def test_preserves_line_endings(self) -> None:
+        with TemporaryDirectory() as workspace:
+            test_file = Path(workspace) / "test.py"
+            for nl in ["\n", "\r\n"]:
+                contents = nl.join(["def f(  ):", "    pass"])
+                test_file.write_bytes(contents.encode())
+                ff(test_file, write_back=black.WriteBack.YES)
+                updated_contents = test_file.read_bytes()
+                self.assertIn(nl.encode(), updated_contents)
+                if nl == "\n":
+                    self.assertNotIn(b"\r\n", updated_contents)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #258 

Note that this only changes behavior when black writes back to the file. In other cases like when using `--diff` or writing to stdout, I think it's reasonable to expect the caller to handle line endings.