### PR TITLE
✨ 🍰 ✨ isn't appropriate when it fails, fixes #300

### DIFF
--- a/black.py
+++ b/black.py
@@ -337,7 +337,7 @@ def main(
         finally:
             shutdown(loop)
     if verbose or not quiet:
-        out("All done! ✨ 🍰 ✨")
+        out("All done!" + ("💥 💔 💥" if report.return_code else " ✨ 🍰 ✨"))
         click.secho(str(report), err=True)
     ctx.exit(report.return_code)
 


### PR DESCRIPTION
It's whimsical but this output feels more appropriate:
```bash
▶ python black.py --check /tmp/foo.py
would reformat /tmp/foo.py
All done!💥 💔 💥
1 file would be reformatted.
▶ python black.py /tmp/foo.py
reformatted /tmp/foo.py
All done! ✨ 🍰 ✨
1 file reformatted.
▶ python black.py --check /tmp/foo.py
All done! ✨ 🍰 ✨
1 file would be left unchanged.
```

PR has no tests. Tips on where to put the tests appreciated. 