### PR TITLE
Link to GitHub + HTTPS + typos

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Treat each other well
 
-Everyone participating in the Black project, and in particular in the
+Everyone participating in the *Black* project, and in particular in the
 issue tracker, pull requests, and social media activity, is expected
 to treat other people with respect and more generally to follow the
 guidelines articulated in the [Python Community Code of

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@ provide some basics for me:
 
 Operating system:
 Python version:
-Black version:
+*Black* version:
 Does also happen on master:
 
 To answer the last question, follow these steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ yet?
 In terms of inspiration, *Black* is about as configurable as *gofmt*.
 This is deliberate.
 
-Bug reports and fixes are always welcome!  Please follow the issue
-template on GitHub for best results.
+Bug reports and fixes are always welcome!  Please follow the [issue
+template on GitHub](https://github.com/ambv/black/issues/new) for best 
+results.
 
 Before you suggest a new feature or configuration knob, ask yourself why
 you want it.  If it enables better integration with some workflow, fixes
@@ -24,7 +25,7 @@ to get accepted. You can still try but prepare to be disappointed.
 ## Technicalities
 
 Development on the latest version of Python is preferred.  As of this
-writing it's 3.6.4.  You can use any operating system.  I am using macOS
+writing it's 3.6.5.  You can use any operating system.  I am using macOS
 myself and CentOS at work.
 
 Install all development dependencies using:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Black
 
 Welcome! Happy to see you willing to make the project better. Have you
-read the entire [user documentation](http://black.readthedocs.io/en/latest/)
+read the entire [user documentation](https://black.readthedocs.io/en/latest/)
 yet?
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Black
+# Contributing to *Black*
 
 Welcome! Happy to see you willing to make the project better. Have you
 read the entire [user documentation](https://black.readthedocs.io/en/latest/)
@@ -35,7 +35,7 @@ $ pre-commit install
 ```
 If you haven't used `pipenv` before but are comfortable with virtualenvs,
 just run `pip install pipenv` in the virtualenv you're already using and
-invoke the command above from the cloned Black repo. It will do the
+invoke the command above from the cloned *Black* repo. It will do the
 correct thing.
 
 Before submitting pull requests, run tests with:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 <p align="center">
 <a href="https://travis-ci.org/ambv/black"><img alt="Build Status" src="https://travis-ci.org/ambv/black.svg?branch=master"></a>
-<a href="http://black.readthedocs.io/en/stable/?badge=stable"><img alt="Documentation Status" src="http://readthedocs.org/projects/black/badge/?version=stable"></a>
+<a href="https://black.readthedocs.io/en/stable/?badge=stable"><img alt="Documentation Status" src="https://readthedocs.org/projects/black/badge/?version=stable"></a>
 <a href="https://coveralls.io/github/ambv/black?branch=master"><img alt="Coverage Status" src="https://coveralls.io/repos/github/ambv/black/badge.svg?branch=master"></a>
-<a href="https://github.com/ambv/black/blob/master/LICENSE"><img alt="License: MIT" src="http://black.readthedocs.io/en/stable/_static/license.svg"></a>
-<a href="https://pypi.python.org/pypi/black"><img alt="PyPI" src="http://black.readthedocs.io/en/stable/_static/pypi.svg"></a>
+<a href="https://github.com/ambv/black/blob/master/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
+<a href="https://pypi.python.org/pypi/black"><img alt="PyPI" src="https://black.readthedocs.io/en/stable/_static/pypi.svg"></a>
 <a href="https://github.com/ambv/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 
@@ -610,7 +610,7 @@ require external contributions.
 Patches welcome! ✨ 🍰 ✨
 
 Any tool that can pipe code through *Black* using its stdio mode (just
-[use `-` as the file name](http://www.tldp.org/LDP/abs/html/special-chars.html#DASHREF2)).
+[use `-` as the file name](https://www.tldp.org/LDP/abs/html/special-chars.html#DASHREF2)).
 The formatted code will be returned on stdout (unless `--check` was
 passed).  *Black* will still emit messages on stderr but that shouldn't
 affect your use case.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ black {source_file_or_directory}
 
 ### Command line options
 
-Black doesn't provide many options.  You can list them by running
+*Black* doesn't provide many options.  You can list them by running
 `black --help`:
 
 ```text
@@ -645,7 +645,7 @@ master, this is also an option.
 
 *Black* remembers files it has already formatted, unless the `--diff` flag is used or
 code is passed via standard input. This information is stored per-user. The exact
-location of the file depends on the black version and the system on which black
+location of the file depends on the *Black* version and the system on which *Black*
 is run. The file is non-portable. The standard location on common operating systems
 is:
 
@@ -658,7 +658,7 @@ is:
 
 **Dusty Phillips**, [writer](https://smile.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords=dusty+phillips):
 
-> Black is opinionated so you don't have to be.
+> *Black* is opinionated so you don't have to be.
 
 **Hynek Schlawack**, [creator of `attrs`](http://www.attrs.org/), core
 developer of Twisted and CPython:
@@ -691,7 +691,7 @@ Looks like this: [![Code style: black](https://img.shields.io/badge/code%20style
 MIT
 
 
-## Contributing to Black
+## Contributing to *Black*
 
 In terms of inspiration, *Black* is about as configurable as *gofmt*.
 This is deliberate.
@@ -840,10 +840,10 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
 * generalized star expression handling, including double stars; this
   fixes multiplication making expressions "unsafe" for trailing commas (#132)
 
-* Black no longer enforces putting empty lines behind control flow statements
+* *Black* no longer enforces putting empty lines behind control flow statements
   (#90)
 
-* Black now splits imports like "Mode 3 + trailing comma" of isort (#127)
+* *Black* now splits imports like "Mode 3 + trailing comma" of isort (#127)
 
 * fixed comment indentation when a standalone comment closes a block (#16, #32)
 
@@ -896,16 +896,16 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
   (#75)
 
 * fixed handling of standalone comments within nested bracketed
-  expressions; Black will no longer produce super long lines or put all
+  expressions; *Black* will no longer produce super long lines or put all
   standalone comments at the end of the expression (#22)
 
 * fixed 18.3a4 regression: don't crash and burn on empty lines with
   trailing whitespace (#80)
 
 * fixed 18.3a4 regression: `# yapf: disable` usage as trailing comment
-  would cause Black to not emit the rest of the file (#95)
+  would cause *Black* to not emit the rest of the file (#95)
 
-* when CTRL+C is pressed while formatting many files, Black no longer
+* when CTRL+C is pressed while formatting many files, *Black* no longer
   freaks out with a flurry of asyncio-related exceptions
 
 * only allow up to two empty lines on module level and only single empty

--- a/black.py
+++ b/black.py
@@ -2258,7 +2258,7 @@ def right_hand_split(
             elif head.contains_multiline_strings() or tail.contains_multiline_strings():
                 raise CannotSplit(
                     "The current optional pair of parentheses is bound to fail to "
-                    "satisfy the splitting algorithm becase the head or the tail "
+                    "satisfy the splitting algorithm because the head or the tail "
                     "contains multiline strings which by definition never fit one "
                     "line."
                 )
@@ -2562,7 +2562,7 @@ def normalize_invisible_parens(node: Node, parens_after: Set[str]) -> None:
 
 
 def maybe_make_parens_invisible_in_atom(node: LN) -> bool:
-    """If it's safe, make the parens in the atom `node` invisible, recusively."""
+    """If it's safe, make the parens in the atom `node` invisible, recursively."""
     if (
         node.type != syms.atom
         or is_empty_tuple(node)

--- a/blib2to3/LICENSE
+++ b/blib2to3/LICENSE
@@ -2,12 +2,12 @@ A. HISTORY OF THE SOFTWARE
 ==========================
 
 Python was created in the early 1990s by Guido van Rossum at Stichting
-Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+Mathematisch Centrum (CWI, see https://www.cwi.nl) in the Netherlands
 as a successor of a language called ABC.  Guido remains Python's
 principal author, although it includes many contributions from others.
 
 In 1995, Guido continued his work on Python at the Corporation for
-National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+National Research Initiatives (CNRI, see https://www.cnri.reston.va.us)
 in Reston, Virginia where he released several versions of the
 software.
 
@@ -19,7 +19,7 @@ https://www.python.org/psf/) was formed, a non-profit organization
 created specifically to own Python-related Intellectual Property.
 Zope Corporation was a sponsoring member of the PSF.
 
-All Python releases are Open Source (see http://www.opensource.org for
+All Python releases are Open Source (see https://opensource.org for
 the Open Source Definition).  Historically, most, but not all, Python
 releases have also been GPL-compatible; the table below summarizes
 the various releases.


### PR DESCRIPTION
* Link to GitHub from the contributing page
* Update the current Python 3.6 minor version
* Update HTTP links to HTTPS, where available
* Fix a couple of typos
* Italicise *Black*