### PR TITLE
vim: add "--skip-string-normalization" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Commands and shortcuts:
 Configuration:
 * `g:black_fast` (defaults to `0`)
 * `g:black_linelength` (defaults to `88`)
+* `g:black_skip_string_normalization` (defaults to `0`)
 * `g:black_virtualenv` (defaults to `~/.vim/black`)
 
 To install with [vim-plug](https://github.com/junegunn/vim-plug):

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -30,6 +30,9 @@ endif
 if !exists("g:black_linelength")
   let g:black_linelength = 88
 endif
+if !exists("g:black_skip_string_normalization")
+  let g:black_skip_string_normalization = 0
+endif
 
 python3 << endpython3
 import sys
@@ -94,9 +97,11 @@ def Black():
   start = time.time()
   fast = bool(int(vim.eval("g:black_fast")))
   line_length = int(vim.eval("g:black_linelength"))
+  if bool(int(vim.eval("g:black_skip_string_normalization"))):
+    mode = black.FileMode.AUTO_DETECT & black.FileMode.NO_STRING_NORMALIZATION
   buffer_str = '\n'.join(vim.current.buffer) + '\n'
   try:
-    new_buffer_str = black.format_file_contents(buffer_str, line_length=line_length, fast=fast)
+    new_buffer_str = black.format_file_contents(buffer_str, line_length=line_length, fast=fast, mode=mode)
   except black.NothingChanged:
     print(f'Already well formatted, good job. (took {time.time() - start:.4f}s)')
   except Exception as exc:


### PR DESCRIPTION
Since 18.6b0 was released, there has been a new option to skip string
normalization when Black is called, but it wasn't able to be specified
from within the vim plugin. This commit adds that functionality.

Tested with g:black_skip_string_normalization set to 0 (off) and 1 (on).