### PR TITLE
Add `-h` as a shortcut for `--help`

### DIFF
--- a/black.py
+++ b/black.py
@@ -191,7 +191,7 @@ def read_pyproject_toml(
     return value
 
 
-@click.command()
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option(
     "-l",
     "--line-length",


### PR DESCRIPTION
I always type `black -h` and then kick myself for not typing `black --help`, this PR being accepted would mean I don't have to kick myself :)
