### PR TITLE
Remove reference to deprecated Visual Studio Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,8 +684,7 @@ to do this.
 ### Visual Studio Code
 
 Use the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-([instructions](https://code.visualstudio.com/docs/python/editing#_formatting))
-or [joslarson.black-vscode](https://marketplace.visualstudio.com/items?itemName=joslarson.black-vscode).
+([instructions](https://code.visualstudio.com/docs/python/editing#_formatting)).
 
 
 ### SublimeText 3


### PR DESCRIPTION
@ambv As promised, I've deprecated my Visual Studio Code extension in favor of the new official Python extension's Black support.