### PR TITLE
Add pyls-black to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,14 @@ Use [sublack plugin](https://github.com/jgirardet/sublack).
 Use [blackcellmagic](https://github.com/csurfer/blackcellmagic).
 
 
+### Python Language Server
+
+If your editor supports the [Language Server Protocol](https://langserver.org/)
+(Atom, Sublime Text, Visual Studio Code and many more), you can use
+the [Python Language Server](https://github.com/palantir/python-language-server) with the
+[pyls-black](https://github.com/rupert/pyls-black) plugin.
+
+
 ### Other editors
 
 Atom/Nuclide integration is planned by the author, others will


### PR DESCRIPTION
I recently wrote a Python Language Server plugin for [Black](https://github.com/rupert/pyls-black). In the `README` you mentioned you were working on a Atom/Nuclide plugin so this may be of interest. To use it from Atom you'll need to install the `atom-ide-ui` and `ide-python` packages.

It would be great if `pyls-black` could be added to the `README` so other people can try it out!