### PR TITLE
Freeze mypy version for CI (fixes #408)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 install:
-- C:\Python36\python.exe -m pip install mypy
+- C:\Python36\python.exe -m pip install mypy==0.600
 - C:\Python36\python.exe -m pip install -e .
 
 # Not a C# project

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 language: python
 cache: pip
 install:
-- pip install coverage coveralls flake8 flake8-bugbear mypy
+- pip install coverage coveralls flake8 flake8-bugbear mypy==0.600
 - pip install -e .
 script:
 - coverage run tests/test_black.py


### PR DESCRIPTION
This freezes the version of mypy in the `pip install` command in `.travis.yml` and `.appveyor.yml` to the one in `Pipfile.lock` (0.600).

A better solution would be to get CI to use `pipenv` to install its dependencies, but I ran into issues setting that up for Travis CI; I'm not sure if pipenv currently works well in Travis CI. Haven't tried this for AppVeyor yet.