### PR TITLE
Deploy linux binary (#362)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,16 @@ matrix:
     - python: 3.6
     - python: 3.7
     - python: 3.8-dev
+before_deploy:
+  - pip install pyinstaller
+  - pyinstaller --clean -F --add-data blib2to3/:blib2to3 black.py
+deploy:
+  provider: releases
+  api_key:
+    secure: HWp0i3tzLox5V+tT5GJ+X6rJATd4dmR6aQe0wpc7FWwrKFKF1fVqQtc8gvzS2e/Wv4Xse/Q0vqze5U6q+aYIysoVkLeZiRJ3YzBHV40/J058MG7PMjyJ1hfxsctVEUIsvKSlF9br21k5C6efem2FrfmuavbRN4sdged5HlFpPYrH65G41Wt/3msdF7NNhDaeup3vne+hVrSdYkLj3qSN5a0htLhWSeT12f5hruBqFN32dVVJrtsI9OeOvy4ASrMm2V3S9+QsR0xQFkCCwFxNF95BVzjRKIT7jcVfKsQ15uJLUonZCLMRqZ0pYfVc11J0yxVIUZ8SK0AU3tW4Fh/+LCHgifHDF9Ua5q6l+YSVZq0aVWZq21m2z/KdlTM6EdBOsAjzvYpY55SLWDCsX0Bkn6QX//E+MnPf0H2oTJ7zm5pOgCCJWXIZnX2+FsnM1W23yc3Uvwld9I33+D3dC5ZOssDpYPTzrVZWOcDYyIQCT3FvgM18xii1uajb8WJQS8Le+oJQAv5UQAB57G+Nr4iKlzpqTcPkRZSKLlTBFfh/lVU+UAMQDQgrUk+4PSOIsYxuQDK3kxdwFYJMI/BztqPidRfCHq/qR2pya/+79dp9VDCe5g2acZ40jIISqVgrezKrjFNKvYmrca8jU9iCOO4QvPiIp9qxcGJCYvctNguAD5A=
+  file: dist/black
+  skip_cleanup: true
+  on:
+    condition: $TRAVIS_PYTHON_VERSION == '3.6'
+    repo: cxong/black
+    tags: true


### PR DESCRIPTION
This uses Travis CI to deploy a linux binary to the GitHub release, you can see an example here:
https://github.com/cxong/black/releases/tag/travis_deploy_test5

Tested the binary under Ubuntu (WSL):
```
$ ./dist/black --version
black, version 18.6b4
```

Note: the same API key can't be used. It must be generated using the `travis` CLI tool, instructions here: https://docs.travis-ci.com/user/deployment/releases/