### PR TITLE
Remove mappings from Vim plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ $ where black
 
 Commands and shortcuts:
 
-* `,=` or `:Black` to format the entire file (ranges not supported);
+* `:Black` to format the entire file (ranges not supported);
 * `:BlackUpgrade` to upgrade *Black* inside the virtualenv;
 * `:BlackVersion` to get the current version of *Black* inside the
   virtualenv.

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -122,6 +122,3 @@ endpython3
 command! Black :py3 Black()
 command! BlackUpgrade :py3 BlackUpgrade()
 command! BlackVersion :py3 BlackVersion()
-
-nmap ,= :Black<CR>
-vmap ,= :Black<CR>


### PR DESCRIPTION
They clashed with standard mappings.  Simplest just to let users define
their own.