### PR TITLE
Deploy windows binary (#362)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,3 +8,18 @@ build: off
 test_script:
 - C:\Python36\python.exe tests/test_black.py
 - C:\Python36\python.exe -m mypy black.py tests/test_black.py
+
+after_test:
+  - C:\Python36\python.exe -m pip install pyinstaller
+  - "%CMD_IN_ENV% C:\\Python36\\python.exe -m PyInstaller --clean -F --add-data blib2to3/;blib2to3 black.py"
+
+artifacts:
+  - path: dist/black.exe
+
+deploy:
+  provider: GitHub
+  description: ''
+  auth_token:
+    secure: caPP8BcGffPuTopDfdI4ZVKZkpD9l9UAcjO7rwm5/fFSMbsqh1v4S38nmMn4uSuD
+  on:
+    appveyor_repo_tag: true


### PR DESCRIPTION
Built using appveyor and uploaded when releases are made. See example: https://github.com/cxong/black/releases/tag/appveyor_deploy_test5

Note: this uploads an .exe which might be blocked depending on your computer settings. Should it zip the exe instead?