### PR TITLE
not enforcing python3.6 for precommit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     description: 'Black: The uncompromising Python code formatter'
     entry: black
     language: python
-    language_version: python3.6
+    language_version: python3
     types: [python]


### PR DESCRIPTION
this should allow precommit hooks to be used with py37