### PR TITLE
write to cache even if the file is unchanged

### DIFF
--- a/black.py
+++ b/black.py
@@ -398,7 +398,7 @@ def reformat_one(
                 mode=mode,
             ):
                 changed = Changed.YES
-            if write_back == WriteBack.YES and changed is not Changed.NO:
+            if write_back == WriteBack.YES and changed is not Changed.CACHED:
                 write_cache(cache, [src], line_length, mode)
         report.done(src, changed)
     except Exception as exc:


### PR DESCRIPTION
Maybe I'm missing something, but it seems useful to write to the cache even if the file is unchanged, so that the next time we run Black, we don't need to look at the file.

However, there is no need to write to the file if the result is already cached.