### PR TITLE
Add reference to atom-python-black

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ the [Python Language Server](https://github.com/palantir/python-language-server)
 
 ### Atom/Nuclide
 
-Use [atom-black](https://github.com/hauntsaninja/atom-black).
+Use [atom-black](https://github.com/hauntsaninja/atom-black) or [python-black](https://github.com/mikehoyio/atom-python-black).
 
 
 ### Other editors


### PR DESCRIPTION
Pull request #456 linked a Black for Atom named [atom-black](https://github.com/hauntsaninja/atom-black) in the Readme.  A plugin named [python-black](https://github.com/mikehoyio/atom-python-black) already existed. I suggest to link both in the Readme.
