### PR TITLE
Add build & dist directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/_static/pypi.svg
 .tox
 __pycache__
 black.egg-info
+build/
+dist/


### PR DESCRIPTION
Generated when running the command `python3 setup.py bdist_wheel`.