### PR TITLE
Update the Poetry section in pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 black.egg-info
 build/
 dist/
+pyproject.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,11 @@ classifiers=[
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
 ]
-# include = ["blib2to3/**/*.py", "blib2to3/*.txt", "blib2to3/LICENSE"]
+
+packages = [
+    {include = "black.py"},
+    {include = "blib2to3"}
+]
 
 [tool.poetry.scripts]
 black = "black:main"


### PR DESCRIPTION
This PR updates the `tool.poetry` section of the `pyproject.toml` file to properly package the project.

This PR should make Poetry the only tool needed to develop and package the project and as such the following files should no longer be needed:

- `MANIFEST.in`
- `Pipfile` and `Pipfile.lock`
- `setup.py`
- `setup.cfg`

I did not remove them in the PR since they might still want to be used by the maintainers, so I let this decision to them.

Also, this will now package the `*.pyi` files, which is not currently the case. If this is not desired, it's possible to exclude them by adding the following line to the `tool.poetry` section:

```toml
exclude = ["**/*.pyi"]
```

Also, if the maintainers want to only rely on Poetry I am willing to update the necessary files (like the CI configuration files) to make it work.

Finally, I added the `pyproject.lock` file to the `.gitignore` file because `black` is a library and as such does not need it.