### PR TITLE
Add trailing comma when a single import doesn't fit on a line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,7 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
 
 * fixed formatting of lambda expressions with default arguments (#468)
 
+* trailing comma is now added to single imports that don't fit on a line (#250)
 
 ### 18.6b4
 

--- a/black.py
+++ b/black.py
@@ -2174,7 +2174,7 @@ def left_hand_split(line: Line, py36: bool = False) -> Iterator[Line]:
             yield result
 
 
-def right_hand_split(
+def right_hand_split(  # noqa C901
     line: Line, line_length: int, py36: bool = False, omit: Collection[LeafID] = ()
 ) -> Iterator[Line]:
     """Split line into many lines, starting with the last matching bracket pair.
@@ -2214,6 +2214,9 @@ def right_hand_split(
         # No `head` means the split failed. Either `tail` has all content or
         # the matching `opening_bracket` wasn't available on `line` anymore.
         raise CannotSplit("No brackets found")
+
+    if line.is_import and len(body_leaves) == 1:
+        body_leaves.append(Leaf(token.COMMA, ","))
 
     # Build the new lines.
     for result, leaves in (head, head_leaves), (body, body_leaves), (tail, tail_leaves):

--- a/tests/data/import_spacing.py
+++ b/tests/data/import_spacing.py
@@ -86,7 +86,7 @@ from some_library import (
     Use,
 )
 from name_of_a_company.extremely_long_project_name.component.ttypes import (
-    CuteLittleServiceHandlerFactoryyy
+    CuteLittleServiceHandlerFactoryyy,
 )
 from name_of_a_company.extremely_long_project_name.extremely_long_component_name.ttypes import *
 


### PR DESCRIPTION
Fixes #250.