### PR TITLE
Update atom plugin location to merged plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ the [Python Language Server](https://github.com/palantir/python-language-server)
 
 ### Atom/Nuclide
 
-Use [atom-black](https://github.com/hauntsaninja/atom-black).
+Use [python-black](https://atom.io/packages/python-black).
 
 
 ### Other editors


### PR DESCRIPTION
Update documentation to link to the merged atom plugin.

Plugin merged the capabilities of https://github.com/hauntsaninja/atom-black/ and https://github.com/mikehoyio/atom-python-black .

This issue is also referenced here #456 .
Collaboration discussion was referenced here https://github.com/mikehoyio/atom-python-black/issues/5

Cheers
Mike