### PR TITLE
Add .nox directories to default exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Options:
                               recursive searches. On Windows, use forward
                               slashes for directories.  [default:
                               build/|buck-out/|dist/|_build/|\.git/|\.hg/|
-                              \.mypy_cache/|\.tox/|\.venv/]
+                              \.mypy_cache/|\.tox/|\.nox/|\.venv/]
   -q, --quiet                 Don't emit non-error messages to stderr. Errors
                               are still emitted, silence those with
                               2>/dev/null.

--- a/black.py
+++ b/black.py
@@ -50,7 +50,7 @@ from blib2to3.pgen2.parse import ParseError
 __version__ = "18.6b4"
 DEFAULT_LINE_LENGTH = 88
 DEFAULT_EXCLUDES = (
-    r"/(\.git|\.hg|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist)/"
+    r"/(\.git|\.hg|\.mypy_cache|\.tox|\.nox|\.venv|_build|buck-out|build|dist)/"
 )
 DEFAULT_INCLUDES = r"\.pyi?$"
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))


### PR DESCRIPTION
[Nox](https://nox.readthedocs.io/) is similar to Tox. It creates a .nox directory that contains virtualenv for testing with different Python versions.