### PR TITLE
Update isort config to use_parentheses instead of combine_as_imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options:
   -S, --skip-string-normalization
                               Don't normalize string quotes or prefixes.
   -N, --skip-numeric-underscore-normalization
-                              Don't normalize underscores in numeric literals.			      
+                              Don't normalize underscores in numeric literals.
   --check                     Don't write the files back, just return the
                               status.  Return code 0 means nothing would
                               change.  Return code 1 means some files would be
@@ -237,13 +237,13 @@ the following configuration.
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
-combine_as_imports=True
+use_parentheses=True
 line_length=88
 ```
 
 The equivalent command line is:
 ```
-$ isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width=88 [ file.py ]
+$ isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 [ file.py ]
 ```
 </details>
 
@@ -546,7 +546,7 @@ other file.
 If you're running with `--verbose`, you will see a blue message if
 a file was found and used.
 
-Please note `blackd` will not use `pyproject.toml` configuration. 
+Please note `blackd` will not use `pyproject.toml` configuration.
 
 
 ### Configuration format
@@ -790,14 +790,14 @@ Options:
 ### Protocol
 
 `blackd` only accepts `POST` requests at the `/` path. The body of the request
-should contain the python source code to be formatted, encoded 
+should contain the python source code to be formatted, encoded
 according to the `charset` field in the `Content-Type` request header. If no
 `charset` is specified, `blackd` assumes `UTF-8`.
 
 There are a few HTTP headers that control how the source is formatted. These
 correspond to command line flags for *Black*. There is one exception to this:
 `X-Protocol-Version` which if present, should have the value `1`, otherwise the
-request is rejected with `HTTP 501` (Not Implemented). 
+request is rejected with `HTTP 501` (Not Implemented).
 
 The headers controlling how code is formatted are:
 


### PR DESCRIPTION
The `combine_as_imports=True` modifies isort style as a side-effect and was not the intended purpose of the suggested change in #250. The problem was that isort was actually replacing the parens with backslash and using `combine_as_imports=True` happened to also produce the same result.

The actual setting should be `use_parentheses` as this tells isort to use parenthesis for line continuation instead of \ for lines over the allotted line length limit and matches precisely what black is outputting.