### PR TITLE
set entry to black instead of python3 -m black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - id: black
       name: black
       language: system
-      entry: python3 -m black
+      entry: black
       types: [python]
     - id: flake8
       name: flake8


### PR DESCRIPTION
On systems where python3.6 is not default python3  (still many linux distro) running `python3 -m black` will faill, trying using python 3.5 or whathever.
