### PR TITLE
patch main to ensure click_patch() gets called

### DIFF
--- a/README.md
+++ b/README.md
@@ -1350,3 +1350,4 @@ Multiple contributions by:
 * [Stavros Korokithakis](mailto:hi@stavros.io)
 * [Sunil Kapil](mailto:snlkapil@gmail.com)
 * [Vishwas B Sharma](mailto:sharma.vishwas88@gmail.com)
+* [Chuck Wooters](mailto:chuck.wooters@microsoft.com)

--- a/black.py
+++ b/black.py
@@ -3663,6 +3663,10 @@ def patch_click() -> None:
             module._verify_python3_env = lambda: None
 
 
-if __name__ == "__main__":
+def patched_main() -> None:
     patch_click()
     main()
+
+
+if __name__ == "__main__":
+    patched_main()

--- a/blackd.py
+++ b/blackd.py
@@ -108,6 +108,10 @@ async def handle(request: web.Request, executor: Executor) -> web.Response:
         return web.Response(status=500, text=str(e))
 
 
-if __name__ == "__main__":
+def patched_main() -> None:
     black.patch_click()
     main()
+
+
+if __name__ == "__main__":
+    patched_main()

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,10 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    entry_points={"console_scripts": ["black=black:main", "blackd=blackd:main [d]"]},
+    entry_points={
+        "console_scripts": [
+            "black=black:patched_main",
+            "blackd=blackd:patched_main [d]",
+        ]
+    },
 )


### PR DESCRIPTION
The `patch_click()` function wasn't called when black was run as a command-line tool. This PR creates a new main function (`patched_main()`) that contains both calls to `patch_click()` and `main()`.

