### PR TITLE
Fix indent calculation with tabs when computing prefixes

### DIFF
--- a/blib2to3/pgen2/driver.py
+++ b/blib2to3/pgen2/driver.py
@@ -131,10 +131,8 @@ class Driver(object):
                     current_line = ""
                     current_column = 0
                     wait_for_nl = False
-            elif char == ' ':
+            elif char in ' \t':
                 current_column += 1
-            elif char == '\t':
-                current_column += 4
             elif char == '\n':
                 # unexpected empty line
                 current_column = 0

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -501,6 +501,19 @@ class BlackTestCase(unittest.TestCase):
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, line_length=ll)
 
+    def test_comment_indentation(self) -> None:
+        contents_tab = "if 1:\n\tif 2:\n\t\tpass\n\t# comment\n\tpass\n"
+        contents_spc = "if 1:\n    if 2:\n        pass\n    # comment\n    pass\n"
+
+        self.assertFormatEqual(fs(contents_spc), contents_spc)
+        self.assertFormatEqual(fs(contents_tab), contents_spc)
+
+        contents_tab = "if 1:\n\tif 2:\n\t\tpass\n\t\t# comment\n\tpass\n"
+        contents_spc = "if 1:\n    if 2:\n        pass\n        # comment\n    pass\n"
+
+        self.assertFormatEqual(fs(contents_tab), contents_spc)
+        self.assertFormatEqual(fs(contents_spc), contents_spc)
+
     def test_report_verbose(self) -> None:
         report = black.Report(verbose=True)
         out_lines = []


### PR DESCRIPTION
Closes #262, bug seems to have been introduced in https://github.com/ambv/black/commit/54d707e10a5bf3d8d352c1bcbc7946bb6f3c01d7. Indent widths in lib2to3 for tabs are actually counted as 1, not 4, so consuming the prefix needs to match that.