### PR TITLE
Format pyi files correctly in the vim plugin

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -102,6 +102,8 @@ def Black():
   mode = black.FileMode.AUTO_DETECT
   if bool(int(vim.eval("g:black_skip_string_normalization"))):
     mode |= black.FileMode.NO_STRING_NORMALIZATION
+  if vim.current.buffer.name.endswith('.pyi'):
+    mode |= black.FileMode.PYI
   buffer_str = '\n'.join(vim.current.buffer) + '\n'
   try:
     new_buffer_str = black.format_file_contents(buffer_str, line_length=line_length, fast=fast, mode=mode)


### PR DESCRIPTION
Right now, the vim plugin formats `pyi` files as `py` files. This PR changes the behavior so that if the filename ends in `.pyi`, it adds the flag to the `mode` argument.