### PR TITLE
Refactor Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ sudo: required
 dist: xenial
 language: python
 cache: pip
+env:
+- TEST_CMD="coverage run tests/test_black.py"
 install:
 - pip install coverage coveralls flake8 flake8-bugbear mypy
 - pip install -e '.[d]'
 script:
 - coverage run tests/test_black.py
-- if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then mypy black.py blackd.py tests/test_black.py; fi
-- if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check --verbose .; fi
-- if [[ $TRAVIS_PYTHON_VERSION == '3.8-dev' ]]; then flake8 black.py blackd.py tests/test_black.py; fi
+- $TEST_CMD
 after_success:
 - coveralls
 notifications:
@@ -17,9 +17,24 @@ notifications:
   on_failure: always
 matrix:
   include:
-    - python: 3.6
-    - python: 3.7
-    - python: 3.8-dev
+    - name: "mypy"
+      python: 3.6
+      env:
+        - TEST_CMD="mypy black.py blackd.py tests/test_black.py"
+    - name: "black"
+      python: 3.7
+      env:
+        - TEST_CMD="black --check --verbose ."
+    - name: "flake8"
+      python: 3.7
+      env:
+        - TEST_CMD="flake8 black.py blackd.py tests/test_black.py"
+    - name: "3.6"
+      python: 3.6
+    - name: "3.7"
+      python: 3.7
+    - name: "3.8-dev"
+      python: 3.8-dev
 before_deploy:
   - pip install pyinstaller
   - pyinstaller --clean -F --add-data blib2to3/:blib2to3 black.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
 - pip install coverage coveralls flake8 flake8-bugbear mypy
 - pip install -e '.[d]'
 script:
-- coverage run tests/test_black.py
 - $TEST_CMD
 after_success:
 - coveralls

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1291,7 +1291,7 @@ class BlackTestCase(unittest.TestCase):
         try:
             list(black.gen_python_files_in_dir(path, root, include, exclude, report))
         except ValueError as ve:
-            self.fail("`get_python_files_in_dir()` failed: {ve}")
+            self.fail(f"`get_python_files_in_dir()` failed: {ve}")
         path.iterdir.assert_called_once()
         child.resolve.assert_called_once()
         child.is_symlink.assert_called_once()


### PR DESCRIPTION
- Run separate jobs for mypy, self-formatting, flake8, and test runs.
- Don't run flake8 in 3.8 because it is broken (and we can't really expect flake8 to always keep up with 3.8 development).