### PR TITLE
Add .eggs to default exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Options:
                               directories that should be excluded on
                               recursive searches. On Windows, use forward
                               slashes for directories.  [default:
-                              build/|buck-out/|dist/|_build/|\.git/|\.hg/|
-                              \.mypy_cache/|\.nox/|\.tox/|\.venv/]
+                              build/|buck-out/|dist/|_build/|\.eggs/|\.git/|
+                              \.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/]
   -q, --quiet                 Don't emit non-error messages to stderr. Errors
                               are still emitted, silence those with
                               2>/dev/null.
@@ -573,7 +573,8 @@ py36 = true
 include = '\.pyi?$'
 exclude = '''
 /(
-    \.git
+    \.eggs
+  | \.git
   | \.hg
   | \.mypy_cache
   | \.tox

--- a/black.py
+++ b/black.py
@@ -51,7 +51,7 @@ from blib2to3.pgen2.parse import ParseError
 __version__ = "18.9b0"
 DEFAULT_LINE_LENGTH = 88
 DEFAULT_EXCLUDES = (
-    r"/(\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)/"
+    r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)/"
 )
 DEFAULT_INCLUDES = r"\.pyi?$"
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ py36 = true
 include = '\.pyi?$'
 exclude = '''
 /(
-    \.git
+    \.eggs
+  | \.git
   | \.hg
   | \.mypy_cache
   | \.tox


### PR DESCRIPTION
If you have a package that you publish using `setuptools_scm` and you use `tox` to run tests etc., you end up with an `.eggs` directory. I think it is safe to assume this can be excluded by default.

We use tox in our CI and use **black** with the `--check` flag, which then fails because **black** formats the .py-files inside the `.eggs` folder.