### PR TITLE
Fix multiprocessing support for Windows binary

### DIFF
--- a/black.py
+++ b/black.py
@@ -8,7 +8,7 @@ import io
 import itertools
 import keyword
 import logging
-from multiprocessing import Manager
+from multiprocessing import Manager, freeze_support
 import os
 from pathlib import Path
 import pickle
@@ -3658,6 +3658,7 @@ def patch_click() -> None:
 
 
 def patched_main() -> None:
+    freeze_support()
     patch_click()
     main()
 

--- a/blackd.py
+++ b/blackd.py
@@ -2,6 +2,7 @@ import asyncio
 from concurrent.futures import Executor, ProcessPoolExecutor
 from functools import partial
 import logging
+from multiprocessing import freeze_support
 
 from aiohttp import web
 import black
@@ -109,6 +110,7 @@ async def handle(request: web.Request, executor: Executor) -> web.Response:
 
 
 def patched_main() -> None:
+    freeze_support()
     black.patch_click()
     main()
 


### PR DESCRIPTION
The black binary generated for Windows builds would fail on reformatting multiple files due to a Windows-specific multiprocessing issue. Fix by calling freeze_support() as described in [Python docs](https://docs.python.org/dev/library/multiprocessing.html#multiprocessing.freeze_support).