### PR TITLE
black.vim: put cursor in last line if old position is invalid

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -112,7 +112,10 @@ def Black():
   else:
     cursor = vim.current.window.cursor
     vim.current.buffer[:] = new_buffer_str.split('\n')[:-1]
-    vim.current.window.cursor = cursor
+    try:
+      vim.current.window.cursor = cursor
+    except vim.error:
+      vim.current.window.cursor = (len(vim.current.buffer), 0)
     print(f'Reformatted in {time.time() - start:.4f}s.')
 
 def BlackUpgrade():


### PR DESCRIPTION
Formatting the following file in vim with `:Black` when cursor is on the last line

```python
print(
    "foooo")
```

produces error

```
Traceback...
...
vim.error: cursor position outside buffer
```

Fix: put cursor on start of last line when this happens.