### PR TITLE
Add support for special comments in multiline functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 .coverage
 _build
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .coverage
 _build
 .DS_Store

--- a/black.py
+++ b/black.py
@@ -2113,7 +2113,7 @@ def split_line(
 
     # we don't want to split special comments like type annotations
     # https://github.com/python/typing/issues/186
-    has_special_comment: bool = False
+    has_special_comment = False
     for leaf in line.leaves:
         for comment in line.comments_after(leaf):
             if leaf.type == token.COMMA and is_special_comment(comment):

--- a/black.py
+++ b/black.py
@@ -2110,8 +2110,18 @@ def split_line(
         return
 
     line_str = str(line).strip("\n")
-    if not line.should_explode and is_line_short_enough(
-        line, line_length=line_length, line_str=line_str
+
+    # we don't want to split special comments like type annotations (https://github.com/python/typing/issues/186)
+    has_special_comment: bool = False
+    for leaf in line.leaves:
+        for comment in line.comments_after(leaf):
+            if leaf.type == token.COMMA and is_special_comment(comment):
+                has_special_comment = True
+
+    if (
+        not has_special_comment
+        and not line.should_explode
+        and is_line_short_enough(line, line_length=line_length, line_str=line_str)
     ):
         yield line
         return
@@ -2457,6 +2467,15 @@ def is_import(leaf: Leaf) -> bool:
             (v == "import" and p and p.type == syms.import_name)
             or (v == "from" and p and p.type == syms.import_from)
         )
+    )
+
+
+def is_special_comment(leaf: Leaf) -> bool:
+    """Return True if the given leaf is a special comment. Only returns true for type comments for now."""
+    t = leaf.type
+    v = leaf.value
+    return bool(
+        (t == token.COMMENT or t == STANDALONE_COMMENT) and (v.startswith("# type:"))
     )
 
 
@@ -2949,6 +2968,7 @@ def ensure_visible(leaf: Leaf) -> None:
 
 def should_explode(line: Line, opening_bracket: Leaf) -> bool:
     """Should `line` immediately be split with `delimiter_split()` after RHS?"""
+
     if not (
         opening_bracket.parent
         and opening_bracket.parent.type in {syms.atom, syms.import_from}

--- a/black.py
+++ b/black.py
@@ -2111,7 +2111,8 @@ def split_line(
 
     line_str = str(line).strip("\n")
 
-    # we don't want to split special comments like type annotations (https://github.com/python/typing/issues/186)
+    # we don't want to split special comments like type annotations
+    # https://github.com/python/typing/issues/186
     has_special_comment: bool = False
     for leaf in line.leaves:
         for comment in line.comments_after(leaf):
@@ -2471,7 +2472,8 @@ def is_import(leaf: Leaf) -> bool:
 
 
 def is_special_comment(leaf: Leaf) -> bool:
-    """Return True if the given leaf is a special comment. Only returns true for type comments for now."""
+    """Return True if the given leaf is a special comment.
+    Only returns true for type comments for now."""
     t = leaf.type
     v = leaf.value
     return bool(

--- a/tests/data/comments6.py
+++ b/tests/data/comments6.py
@@ -1,5 +1,12 @@
 from typing import Any, Tuple
 
+
+def f(
+    a,  # type: int
+):
+    pass
+
+
 # test type comments
 def f(a, b, c, d, e, f, g, h, i):
     # type: (int, int, int, int, int, int, int, int, int) -> None
@@ -23,8 +30,8 @@ def f(
 
 def f(
     arg,  # type: int
-    another_arg_with_default_value=False,  # type: bool
     *args,  # type: *Any
+    default=False,  # type: bool
     **kwargs,  # type: **Any
 ):
     # type: (...) -> None

--- a/tests/data/comments6.py
+++ b/tests/data/comments6.py
@@ -1,0 +1,56 @@
+# test type comments
+def f(a, b, c, d, e, f, g, h, i):
+    # type: (int, int, int, int, int, int, int, int, int) -> None
+    pass
+
+
+def f(
+    a,  # type: int
+    b,  # type: int
+    c,  # type: int
+    d,  # type: int
+    e,  # type: int
+    f,  # type: int
+    g,  # type: int
+    h,  # type: int
+    i,  # type: int
+):
+    # type: (...) -> None
+    pass
+
+
+def f(
+    a,  # type: int
+    b,  # type: int
+    c,  # type: int
+    d,  # type: int
+):
+    # type: (...) -> None
+    e = (
+        a
+        + b
+        + c
+        + d
+        + a
+        + b
+        + c
+        + d
+        + a
+        + b
+        + c
+        + d
+        + a
+        + b
+        + c
+        + d
+        + a
+        + b
+        + c
+        + d
+        + a
+        + b
+        + c
+        + d
+    )  # type: int
+
+    g = ""  # type: str

--- a/tests/data/comments6.py
+++ b/tests/data/comments6.py
@@ -1,3 +1,5 @@
+from typing import Any, Tuple
+
 # test type comments
 def f(a, b, c, d, e, f, g, h, i):
     # type: (int, int, int, int, int, int, int, int, int) -> None
@@ -20,37 +22,40 @@ def f(
 
 
 def f(
+    arg,  # type: int
+    another_arg_with_default_value=False,  # type: bool
+    *args,  # type: *Any
+    **kwargs,  # type: **Any
+):
+    # type: (...) -> None
+    pass
+
+
+def f(
     a,  # type: int
     b,  # type: int
     c,  # type: int
     d,  # type: int
 ):
     # type: (...) -> None
-    e = (
-        a
-        + b
-        + c
-        + d
-        + a
-        + b
-        + c
-        + d
-        + a
-        + b
-        + c
-        + d
-        + a
-        + b
-        + c
-        + d
-        + a
-        + b
-        + c
-        + d
-        + a
-        + b
-        + c
-        + d
+
+    element = 0  # type: int
+    another_element = 1  # type: float
+    another_element_with_long_name = 2  # type: int
+    another_really_really_long_element_with_a_unnecessarily_long_name_to_describe_what_it_does_enterprise_style = (
+        3
     )  # type: int
 
-    g = ""  # type: str
+    tup = (
+        another_element,  # type: int
+        another_really_really_long_element_with_a_unnecessarily_long_name_to_describe_what_it_does_enterprise_style,  # type: int
+    )  # type: Tuple[int, int]
+
+    a = (
+        element
+        + another_element
+        + another_element_with_long_name
+        + element
+        + another_element
+        + another_element_with_long_name
+    )  # type: int

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -363,6 +363,14 @@ class BlackTestCase(unittest.TestCase):
         black.assert_stable(source, actual, line_length=ll)
 
     @patch("black.dump_to_file", dump_to_stderr)
+    def test_comments6(self) -> None:
+        source, expected = read_data("comments6")
+        actual = fs(source)
+        self.assertFormatEqual(expected, actual)
+        black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, line_length=ll)
+
+    @patch("black.dump_to_file", dump_to_stderr)
     def test_cantfit(self) -> None:
         source, expected = read_data("cantfit")
         actual = fs(source)


### PR DESCRIPTION
This is a starter diff to deal with #282, and I'm happy to iterate on it.

We want to ensure that type comments (https://www.python.org/dev/peps/pep-0484/) for Python 2 are formatted in a valid way, so that we can use Black in our organization.