### PR TITLE
Fix instructions for PyCharm integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ $ where black
 %LocalAppData%\Programs\Python\Python36-32\Scripts\black.exe  # possible location
 ```
 
-3. Open External tools in PyCharm with `File -> Settings -> Tools -> External Tools`.
+3. Open External tools in PyCharm with `PyCharm -> Preferences -> Tools -> External Tools`.
 
 4. Click the + icon to add a new external tool with the following values:
     - Name: Black
@@ -644,12 +644,12 @@ $ where black
     - Arguments: `$FilePath$`
 
 5. Format the currently opened file by selecting `Tools -> External Tools -> black`.
-    - Alternatively, you can set a keyboard shortcut by navigating to `Preferences -> Keymap -> External Tools -> External Tools - Black`.
+    - Alternatively, you can set a keyboard shortcut by navigating to `PyCharm -> Preferences -> Keymap -> External Tools -> External Tools - Black`.
 
 6. Optionally, run Black on every file save:
 
     1. Make sure you have the [File Watcher](https://plugins.jetbrains.com/plugin/7177-file-watchers) plugin installed.
-    2. Go to `Preferences -> Tools -> File Watchers` and click `+` to add a new watcher:
+    2. Go to `PyCharm -> Preferences -> Tools -> File Watchers` and click `+` to add a new watcher:
         - Name: Black
         - File type: Python
         - Scope: Project Files


### PR DESCRIPTION
The instructions for navigating through PyCharm to enable black integration are slightly off. The first navigation is for a Windows user. However, the latter two are for Mac users; though the latter two are missing the first step in the navigation.

Only difference between PyCharm for Mac and Windows is navigating to the Preferences (or Settings) menu:

Mac: `PyCharm -> Preferences`
Windows: `File -> Settings`

Please note I adjusted the instructions for a Mac user. Figure this could help someone down the road as it took me some time to figure out.