### PR TITLE
Improve an error message when failed to load pyproject.toml

### DIFF
--- a/black.py
+++ b/black.py
@@ -160,7 +160,9 @@ def read_pyproject_toml(
         pyproject_toml = toml.load(value)
         config = pyproject_toml.get("tool", {}).get("black", {})
     except (toml.TomlDecodeError, OSError) as e:
-        raise click.BadOptionUsage(f"Error reading configuration file: {e}", ctx)
+        raise click.FileError(
+            filename=value, hint=f"Error reading configuration file: {e}"
+        )
 
     if not config:
         return None


### PR DESCRIPTION
This PR aims to improve the information content of an error message when failed to load `pyproject.toml` file.

Like #637, current `black 18.9b0 (and master branch)` output the following error message when `pyproject.toml` malformed or `toml` package considers the format is invalid:

```
$ black .
Usage: black [OPTIONS] [SRC]...

Error: <click.core.Context object at 0x7f51c84264e0>
```

I think that it is difficult to understand the cause of the error from the message.
After applying the patch, the message looks like below:

```
$ black .
Error: Could not open file /home/.../pyproject.toml: Error reading configuration file: Invalid date or number (line 36 column 1 char 478)
```