### PR TITLE
Don't use Python 3.6 grammar on files using future-fstrings

### DIFF
--- a/black.py
+++ b/black.py
@@ -632,7 +632,11 @@ def format_str(
     dst_contents = ""
     future_imports = get_future_imports(src_node)
     is_pyi = bool(mode & FileMode.PYI)
-    py36 = bool(mode & FileMode.PYTHON36) or is_python36(src_node)
+    py36 = (                                                                                                                
+        bool(mode & FileMode.PYTHON36)
+        or "# -*- coding: future_fstrings -*-" not in src_contents
+        and is_python36(src_node)
+    )
     normalize_strings = not bool(mode & FileMode.NO_STRING_NORMALIZATION)
     normalize_fmt_off(src_node)
     lines = LineGenerator(


### PR DESCRIPTION
Projects that support older versions of Python and use future-fstrings package to backport fstrings are currently broken when reformatted with Black, because it uses Python 3.6-only grammar. The patch checks for '# -*- coding: future_fstrings -*-' in the files, so they don't get falsely flagged as Python 3.6 compatible.

I am considering how to best implement the tests for this. Any advice in that regard would be welcome!