### PR TITLE
Update README.md - Pycharm instructions not working for files path containing white spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,15 @@ $ where black
 %LocalAppData%\Programs\Python\Python36-32\Scripts\black.exe  # possible location
 ```
 
-3. Open External tools in PyCharm with `File -> Settings -> Tools -> External Tools`.
+3. Open External tools in PyCharm  
+
+  On macOS / Linux / BSD:
+  
+```PyCharm -> Preferences -> Tools -> External Tools```
+
+  On Windows:
+  
+```File -> Settings -> Tools -> External Tools```
 
 4. Click the + icon to add a new external tool with the following values:
     - Name: Black

--- a/README.md
+++ b/README.md
@@ -637,11 +637,11 @@ $ where black
 
 3. Open External tools in PyCharm  
 
-  On macOS / Linux / BSD:
+  On macOS:
   
 ```PyCharm -> Preferences -> Tools -> External Tools```
 
-  On Windows:
+  On Windows / Linux / BSD:
   
 ```File -> Settings -> Tools -> External Tools```
 

--- a/README.md
+++ b/README.md
@@ -652,12 +652,12 @@ $ where black
     - Arguments: `"$FilePath$"`
 
 5. Format the currently opened file by selecting `Tools -> External Tools -> black`.
-    - Alternatively, you can set a keyboard shortcut by navigating to `Preferences -> Keymap -> External Tools -> External Tools - Black`.
+    - Alternatively, you can set a keyboard shortcut by navigating to `Preferences or Settings -> Keymap -> External Tools -> External Tools - Black`.
 
 6. Optionally, run Black on every file save:
 
     1. Make sure you have the [File Watcher](https://plugins.jetbrains.com/plugin/7177-file-watchers) plugin installed.
-    2. Go to `Preferences -> Tools -> File Watchers` and click `+` to add a new watcher:
+    2. Go to `Preferences or Settings -> Tools -> File Watchers` and click `+` to add a new watcher:
         - Name: Black
         - File type: Python
         - Scope: Project Files

--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ $ where black
     - Name: Black
     - Description: Black is the uncompromising Python code formatter.
     - Program: <install_location_from_step_2>
-    - Arguments: `$FilePath$`
+    - Arguments: `"$FilePath$"`
 
 5. Format the currently opened file by selecting `Tools -> External Tools -> black`.
     - Alternatively, you can set a keyboard shortcut by navigating to `Preferences -> Keymap -> External Tools -> External Tools - Black`.


### PR DESCRIPTION
Currently, If there is a space in the file path of the python file in PyCharm then an error is generated

Error: Invalid value for "[SRC]...": Path .... does not exist.

It stops the file path at the space.

By enclosing the Arguments in quotes it fixes this. 

Also a small issue in that the instructions for how to access settings were incorrect on the Mac