### PR TITLE
show how to exclude individual files in the exclude example

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,12 +572,11 @@ line-length = 88
 py36 = true
 include = '\.pyi?$'
 exclude = '''
-# exclude a few common directories as well as foo.py
-# in the root of the project
+
 (
   /(
-      \.eggs
-    | \.git
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
     | \.hg
     | \.mypy_cache
     | \.tox
@@ -587,7 +586,8 @@ exclude = '''
     | build
     | dist
   )/
-  | foo.py
+  | foo.py           # also separately exclude a file named foo.py in
+                     # the root of the project
 )
 '''
 

--- a/README.md
+++ b/README.md
@@ -572,24 +572,24 @@ line-length = 88
 py36 = true
 include = '\.pyi?$'
 exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-
-  # The following are specific to Black, you probably don't want those.
-  | blib2to3
-  | tests/data
-)/
+# exclude a few common directories as well as foo.py
+# in the root of the project
+(
+  /(
+      \.eggs
+    | \.git
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | foo.py
+)
 '''
-```
 
 </details>
 


### PR DESCRIPTION
It took me about a half hour this morning to puzzle out how to exclude individual files because I didn't realize the example regex excludes only directories. It perhaps took me longer than others since I'm not terribly comfortable with regular expressions but I think this is a common enough desire (to exclude an enumerated list of files along with whole directories) that it should be in the example. Hope you agree :smile:.