### PR TITLE
Atomically write cache files

### DIFF
--- a/black.py
+++ b/black.py
@@ -14,6 +14,7 @@ import pickle
 import re
 import signal
 import sys
+import tempfile
 import tokenize
 from typing import (
     Any,
@@ -3647,11 +3648,11 @@ def write_cache(
     """Update the cache file."""
     cache_file = get_cache_file(line_length, mode)
     try:
-        if not CACHE_DIR.exists():
-            CACHE_DIR.mkdir(parents=True)
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
         new_cache = {**cache, **{src.resolve(): get_cache_info(src) for src in sources}}
-        with cache_file.open("wb") as fobj:
-            pickle.dump(new_cache, fobj, protocol=pickle.HIGHEST_PROTOCOL)
+        with tempfile.NamedTemporaryFile(dir=str(cache_file.parent), delete=False) as f:
+            pickle.dump(new_cache, f, protocol=pickle.HIGHEST_PROTOCOL)
+        os.replace(f.name, cache_file)
     except OSError:
         pass
 

--- a/blib2to3/pgen2/grammar.py
+++ b/blib2to3/pgen2/grammar.py
@@ -13,7 +13,9 @@ fallback token code OP, but the parser needs the actual token code.
 """
 
 # Python imports
+import os.path
 import pickle
+import tempfile
 
 # Local imports
 from . import token
@@ -86,8 +88,9 @@ class Grammar(object):
 
     def dump(self, filename):
         """Dump the grammar tables to a pickle file."""
-        with open(filename, "wb") as f:
+        with tempfile.NamedTemporaryFile(dir=os.path.dirname(filename), delete=False) as f:
             pickle.dump(self.__dict__, f, pickle.HIGHEST_PROTOCOL)
+        os.replace(f.name, filename)
 
     def load(self, filename):
         """Load the grammar tables from a pickle file."""


### PR DESCRIPTION
Resolves #673

Before:

```console
$ find x -name "*.py" | xargs -P8 --replace bash -c 'rm -rf ~/Library/Caches/black && black -q {}'
error: cannot format x/57.py: Ran out of input
error: cannot format x/77.py: Ran out of input
$ find x -name "*.py" | xargs -P8 --replace bash -c 'rm -rf ~/Library/Caches/black && black -q {}'
error: cannot format x/75.py: Ran out of input
error: cannot format x/85.py: Ran out of input
error: cannot format x/73.py: Ran out of input
$ find x -name "*.py" | xargs -P8 --replace bash -c 'rm -rf ~/Library/Caches/black && black -q {}'
error: cannot format x/31.py: Ran out of input
error: cannot format x/35.py: Ran out of input
error: cannot format x/30.py: Ran out of input
error: cannot format x/79.py: Ran out of input
error: cannot format x/49.py: Ran out of input
error: cannot format x/23.py: Ran out of input
```

After:

```console
$ find x -name "*.py" | xargs -P8 --replace bash -c 'rm -rf ~/Library/Caches/black && black -q {}'
$ find x -name "*.py" | xargs -P8 --replace bash -c 'rm -rf ~/Library/Caches/black && black -q {}'
$ find x -name "*.py" | xargs -P8 --replace bash -c 'rm -rf ~/Library/Caches/black && black -q {}'
```