### PR TITLE
Turn off pre-commit's automatic parallelization for black

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,5 @@
     entry: black
     language: python
     language_version: python3
+    require_serial: true
     types: [python]


### PR DESCRIPTION
black internally uses multiprocessing for speed.  In pre-commit 1.13.0 this is automated by the framework itself however if both pre-commit and black are forking processes this is slower and hits race-conditions in `black`.