### PR TITLE
Add PyCharm setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ $ where black
         - Arguments: `$FilePath$`
         - Output paths to refresh: `$FilePathRelativeToProjectRoot$`
         - Working directory: `$ProjectFileDir$`
+	- Uncheck "Auto-save edited files to trigger the watcher"
 
 ### Vim
 


### PR DESCRIPTION
The file watcher is unusable on PyCharm without this additional step -- it constantly triggers in the middle of editing, which then creates conflicts between what is in memory and what is on disk.