### PR TITLE
chore: Fix noqa comment

### DIFF
--- a/black.py
+++ b/black.py
@@ -1606,7 +1606,7 @@ BRACKETS = OPENING_BRACKETS | CLOSING_BRACKETS
 ALWAYS_NO_SPACE = CLOSING_BRACKETS | {token.COMMA, STANDALONE_COMMENT}
 
 
-def whitespace(leaf: Leaf, *, complex_subscript: bool) -> str:  # noqa C901
+def whitespace(leaf: Leaf, *, complex_subscript: bool) -> str:  # noqa: C901
     """Return whitespace prefix if needed for the given `leaf`.
 
     `complex_subscript` signals whether the given leaf is part of a subscription


### PR DESCRIPTION
Omitting the colon makes Flake8 ignore all errors, rather than the specific code.