### PR TITLE
Fix end of codeblock to re-show rest of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ exclude = '''
                      # the root of the project
 )
 '''
+```
 
 </details>
 


### PR DESCRIPTION
https://github.com/ambv/black/pull/663 removed the triple-backticks, so the codeblock never ends and the rest of the README is hidden in the `<summary>`'s `<details>`.

# Before

![image](https://user-images.githubusercontent.com/1324225/52332884-8b7d6f00-2a04-11e9-9963-5cd0740de4ca.png)

https://github.com/ambv/black/blob/9d749280bb1051991d391e0ee70174a613da16fc/README.md

# After

![image](https://user-images.githubusercontent.com/1324225/52332959-ad76f180-2a04-11e9-9f99-8c67c514dda7.png)

...

![image](https://user-images.githubusercontent.com/1324225/52332973-b5cf2c80-2a04-11e9-850e-68791e701c72.png)

https://github.com/hugovk/black/blob/5eafb5ef49831f3d9e886d3b3e0676c6c8f2ac17/README.md