### PR TITLE
CI: 'sudo: required' no longer required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: xenial
 language: python
 cache: pip


### PR DESCRIPTION
The `sudo` keyword is deprecated.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration