### PR TITLE
Properly close the code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ exclude = '''
                      # the root of the project
 )
 '''
+```
 
 </details>
 


### PR DESCRIPTION
Now the code block is not closed and the entire rest of the file is considered to be a code inside the `<details>` expandable section.