### PR TITLE
remove Python implementation-specific versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ black [OPTIONS] [SRC]...
 Options:
   -l, --line-length INTEGER       How many characters per line to allow.
                                   [default: 88]
-  -t, --target-version [pypy35|cpy27|cpy33|cpy34|cpy35|cpy36|cpy37|cpy38]
+  -t, --target-version [py27|py33|py34|py35|py36|py37|py38]
                                   Python versions that should be supported by
                                   Black's output. [default: per-file auto-
                                   detection]
@@ -571,7 +571,7 @@ to denote a significant space character.
 ```toml
 [tool.black]
 line-length = 88
-target_version = ['cpy37']
+target_version = ['py37']
 include = '\.pyi?$'
 exclude = '''
 
@@ -817,8 +817,8 @@ The headers controlling how code is formatted are:
  - `X-Python-Variant`: if set to `pyi`, `blackd` will act as *Black* does when
     passed the `--pyi` command line flag. Otherwise, its value must correspond to
     a Python version or a set of comma-separated Python versions, optionally
-    prefixed with `cpy` or `pypy`. For example, to request code that is compatible
-    with PyPy 3.5 and CPython 3.5, set the header to `pypy3.5,cpy3.5`.
+    prefixed with `py`. For example, to request code that is compatible
+    with Python 3.5 and 3.6, set the header to `py3.5,py3.6`.
 
 If any of these headers are set to invalid values, `blackd` returns a `HTTP 400`
 error response, mentioning the name of the problematic header in the message body.
@@ -939,7 +939,7 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
 
 ### 19.2b0
 
-* removed `--py36` (use `--target-version=cpy36` instead) (#724)
+* removed `--py36` (use `--target-version=py36` instead) (#724)
 
 * long `del` statements are now split into multiple lines (#698)
 

--- a/black.py
+++ b/black.py
@@ -113,20 +113,19 @@ class Changed(Enum):
 
 
 class TargetVersion(Enum):
-    PYPY35 = 1
-    CPY27 = 2
-    CPY33 = 3
-    CPY34 = 4
-    CPY35 = 5
-    CPY36 = 6
-    CPY37 = 7
-    CPY38 = 8
+    PY27 = 2
+    PY33 = 3
+    PY34 = 4
+    PY35 = 5
+    PY36 = 6
+    PY37 = 7
+    PY38 = 8
 
     def is_python2(self) -> bool:
-        return self is TargetVersion.CPY27
+        return self is TargetVersion.PY27
 
 
-PY36_VERSIONS = {TargetVersion.CPY36, TargetVersion.CPY37, TargetVersion.CPY38}
+PY36_VERSIONS = {TargetVersion.PY36, TargetVersion.PY37, TargetVersion.PY38}
 
 
 class Feature(Enum):
@@ -138,24 +137,23 @@ class Feature(Enum):
 
 
 VERSION_TO_FEATURES: Dict[TargetVersion, Set[Feature]] = {
-    TargetVersion.CPY27: set(),
-    TargetVersion.PYPY35: {Feature.UNICODE_LITERALS, Feature.F_STRINGS},
-    TargetVersion.CPY33: {Feature.UNICODE_LITERALS},
-    TargetVersion.CPY34: {Feature.UNICODE_LITERALS},
-    TargetVersion.CPY35: {Feature.UNICODE_LITERALS, Feature.TRAILING_COMMA},
-    TargetVersion.CPY36: {
+    TargetVersion.PY27: set(),
+    TargetVersion.PY33: {Feature.UNICODE_LITERALS},
+    TargetVersion.PY34: {Feature.UNICODE_LITERALS},
+    TargetVersion.PY35: {Feature.UNICODE_LITERALS, Feature.TRAILING_COMMA},
+    TargetVersion.PY36: {
         Feature.UNICODE_LITERALS,
         Feature.F_STRINGS,
         Feature.NUMERIC_UNDERSCORES,
         Feature.TRAILING_COMMA,
     },
-    TargetVersion.CPY37: {
+    TargetVersion.PY37: {
         Feature.UNICODE_LITERALS,
         Feature.F_STRINGS,
         Feature.NUMERIC_UNDERSCORES,
         Feature.TRAILING_COMMA,
     },
-    TargetVersion.CPY38: {
+    TargetVersion.PY38: {
         Feature.UNICODE_LITERALS,
         Feature.F_STRINGS,
         Feature.NUMERIC_UNDERSCORES,

--- a/blackd.py
+++ b/blackd.py
@@ -127,12 +127,8 @@ def parse_python_variant_header(value: str) -> Tuple[bool, Set[black.TargetVersi
     else:
         versions = set()
         for version in value.split(","):
-            tag = "cpy"
-            if version.startswith("cpy"):
-                version = version[len("cpy") :]
-            elif version.startswith("pypy"):
-                tag = "pypy"
-                version = version[len("pypy") :]
+            if version.startswith("py"):
+                version = version[len("py") :]
             major_str, *rest = version.split(".")
             try:
                 major = int(major_str)
@@ -147,16 +143,12 @@ def parse_python_variant_header(value: str) -> Tuple[bool, Set[black.TargetVersi
                 else:
                     # Default to lowest supported minor version.
                     minor = 7 if major == 2 else 3
-                version_str = f"{tag.upper()}{major}{minor}"
-                # If PyPY is the same as CPython in some version, use
-                # the corresponding CPython version.
-                if tag == "pypy" and not hasattr(black.TargetVersion, version_str):
-                    version_str = f"CPY{major}{minor}"
+                version_str = f"PY{major}{minor}"
                 if major == 3 and not hasattr(black.TargetVersion, version_str):
                     raise InvalidVariantHeader(f"3.{minor} is not supported")
                 versions.add(black.TargetVersion[version_str])
             except (KeyError, ValueError):
-                raise InvalidVariantHeader("expected e.g. '3.7', 'pypy3.5'")
+                raise InvalidVariantHeader("expected e.g. '3.7', 'py3.5'")
         return False, versions
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 
 [tool.black]
 line-length = 88
-target_version = ['cpy36', 'cpy37', 'cpy38']
+target_version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1202,7 +1202,7 @@ class BlackTestCase(unittest.TestCase):
         source, expected = read_data("force_py36")
         result = CliRunner().invoke(
             black.main,
-            ["-", "-q", "--target-version=cpy36"],
+            ["-", "-q", "--target-version=py36"],
             input=BytesIO(source.encode("utf8")),
         )
         self.assertEqual(result.exit_code, 0)
@@ -1425,9 +1425,9 @@ class BlackTestCase(unittest.TestCase):
             await check("lol")
             await check("ruby3.5")
             await check("pyi3.6")
-            await check("cpy1.5")
+            await check("py1.5")
             await check("2.8")
-            await check("cpy2.8")
+            await check("py2.8")
             await check("3.0")
             await check("pypy3.0")
             await check("jython3.4")
@@ -1466,17 +1466,15 @@ class BlackTestCase(unittest.TestCase):
                 self.assertEqual(response.status, expected_status)
 
             await check("3.6", 200)
-            await check("cpy3.6", 200)
+            await check("py3.6", 200)
             await check("3.5,3.7", 200)
-            await check("3.5,cpy3.7", 200)
+            await check("3.5,py3.7", 200)
 
             await check("2", 204)
             await check("2.7", 204)
-            await check("cpy2.7", 204)
-            await check("pypy2.7", 204)
+            await check("py2.7", 204)
             await check("3.4", 204)
-            await check("cpy3.4", 204)
-            await check("pypy3.4", 204)
+            await check("py3.4", 204)
 
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @async_test


### PR DESCRIPTION
We don't actually need the implementation in the tag; what matters is the Python language version.