### PR TITLE
Fix PendingDeprecationWarning: Task.all_tasks() is deprecated, use asyncio.all_tasks() instead

### DIFF
--- a/black.py
+++ b/black.py
@@ -3436,8 +3436,12 @@ def cancel(tasks: Iterable[asyncio.Task]) -> None:
 def shutdown(loop: BaseEventLoop) -> None:
     """Cancel all pending tasks on `loop`, wait for them, and close the loop."""
     try:
+        if sys.version_info[:2] >= (3, 7):
+            all_tasks = asyncio.all_tasks
+        else:
+            all_tasks = asyncio.Task.all_tasks
         # This part is borrowed from asyncio/runners.py in Python 3.7b2.
-        to_cancel = [task for task in asyncio.Task.all_tasks(loop) if not task.done()]
+        to_cancel = [task for task in all_tasks(loop) if not task.done()]
         if not to_cancel:
             return
 


### PR DESCRIPTION
Same sort of thing as https://github.com/home-assistant/home-assistant/pull/21713.

# Before

```console
$ pytest
============================================= test session starts =============================================
platform darwin -- Python 3.7.2, pytest-4.3.0, py-1.5.4, pluggy-0.7.1
rootdir: /Users/hugo/github/black, inifile:
plugins: requests-mock-1.5.2, xdist-1.26.1, parallel-0.0.9, forked-1.0.1, cov-2.6.1, flaky-3.5.3
collected 90 items

tests/test_black.py ...ssssssssssss.................................................................... [ 92%]
.......                                                                                                 [100%]

============================================== warnings summary ===============================================
tests/test_black.py::BlackTestCase::test_cache_multiple_files
tests/test_black.py::BlackTestCase::test_check_diff_use_together
tests/test_black.py::BlackTestCase::test_failed_formatting_does_not_get_cached
tests/test_black.py::BlackTestCase::test_multi_file_force_py36
tests/test_black.py::BlackTestCase::test_multi_file_force_pyi
  /Users/hugo/github/black/black.py:3440: PendingDeprecationWarning: Task.all_tasks() is deprecated, use asyncio.all_tasks() instead
    to_cancel = [task for task in asyncio.Task.all_tasks(loop) if not task.done()]

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===Flaky Test Report===


===End Flaky Test Report===
============================= 78 passed, 12 skipped, 5 warnings in 17.64 seconds ==============================
```

# After

```console
$ pytest
============================================= test session starts =============================================
platform darwin -- Python 3.7.2, pytest-4.3.0, py-1.5.4, pluggy-0.7.1
rootdir: /Users/hugo/github/black, inifile:
plugins: requests-mock-1.5.2, xdist-1.26.1, parallel-0.0.9, forked-1.0.1, cov-2.6.1, flaky-3.5.3
collected 90 items

tests/test_black.py ...ssssssssssss.................................................................... [ 92%]
.......                                                                                                 [100%]
===Flaky Test Report===


===End Flaky Test Report===

=================================== 78 passed, 12 skipped in 16.39 seconds ====================================
```

https://github.com/home-assistant/home-assistant/pull/21713