### PR TITLE
Add back --py36 as a deprecated option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Options:
                                   Python versions that should be supported by
                                   Black's output. [default: per-file auto-
                                   detection]
+  --py36                          Allow using Python 3.6-only syntax on all
+                                  input files.  This will put trailing commas
+                                  in function signatures and calls also after
+                                  *args and **kwargs. Deprecated; use
+                                  --target-version instead. [default: per-file
+                                  auto-detection]
   --pyi                           Format all input files like typing stubs
                                   regardless of file extension (useful when
                                   piping source on standard input).
@@ -942,7 +948,7 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
 * new option `--target-version` to control which Python versions
   *Black*-formatted code should target (#618)
 
-* removed `--py36` (use `--target-version=py36` instead) (#724)
+* deprecated `--py36` (use `--target-version=py36` instead) (#724)
 
 * *Black* no longer normalizes numeric literals to include `_` separators (#696)
 

--- a/black.py
+++ b/black.py
@@ -247,6 +247,16 @@ def read_pyproject_toml(
     ),
 )
 @click.option(
+    "--py36",
+    is_flag=True,
+    help=(
+        "Allow using Python 3.6-only syntax on all input files.  This will put "
+        "trailing commas in function signatures and calls also after *args and "
+        "**kwargs. Deprecated; use --target-version instead. "
+        "[default: per-file auto-detection]"
+    ),
+)
+@click.option(
     "--pyi",
     is_flag=True,
     help=(
@@ -349,6 +359,7 @@ def main(
     diff: bool,
     fast: bool,
     pyi: bool,
+    py36: bool,
     skip_string_normalization: bool,
     quiet: bool,
     verbose: bool,
@@ -360,7 +371,17 @@ def main(
     """The uncompromising code formatter."""
     write_back = WriteBack.from_configuration(check=check, diff=diff)
     if target_version:
-        versions = set(target_version)
+        if py36:
+            err(f"Cannot use both --target-version and --py36")
+            ctx.exit(2)
+        else:
+            versions = set(target_version)
+    elif py36:
+        err(
+            "--py36 is deprecated and will be removed in a future version. "
+            "Use --target-version py36 instead."
+        )
+        versions = PY36_VERSIONS
     else:
         # We'll autodetect later.
         versions = set()


### PR DESCRIPTION
This partially reverts commit 21ab37a5d92c866a289320cba7c4689df70b3342.