### PR TITLE
fix incorrect call to `right_hand_split()`

### DIFF
--- a/black.py
+++ b/black.py
@@ -2206,7 +2206,7 @@ def split_line(
             # All splits failed, best effort split with no omits.
             # This mostly happens to multiline strings that are by definition
             # reported as not fitting a single line.
-            yield from right_hand_split(line, supports_trailing_commas)
+            yield from right_hand_split(line, line_length, supports_trailing_commas)
 
         if line.inside_brackets:
             split_funcs = [delimiter_split, standalone_comment_split, rhs]

--- a/tests/data/composition.py
+++ b/tests/data/composition.py
@@ -166,17 +166,14 @@ class C:
             _C.__init__.__code__.co_firstlineno + 1,
         )
 
-        assert (
-            expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect
-            == {
-                key1: value1,
-                key2: value2,
-                key3: value3,
-                key4: value4,
-                key5: value5,
-                key6: value6,
-                key7: value7,
-                key8: value8,
-                key9: value9,
-            }
-        )
+        assert expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect == {
+            key1: value1,
+            key2: value2,
+            key3: value3,
+            key4: value4,
+            key5: value5,
+            key6: value6,
+            key7: value7,
+            key8: value8,
+            key9: value9,
+        }


### PR DESCRIPTION
The second argument to `right_hand_split()` is an int (line length), but we were passing `supports_trailing_commas` as a bool. Mypy didn't catch this because bool is a subclass of int. Found this while working on a fix for #759 because I changed the type of `supports_trailing_commas`.

This affects one test that is now formatted differently, and it also causes a fair number of changes in our codebase. Now that I look at it, in most cases I actually feel like the old formatting is better, so maybe we need to do something different than just fix the type mismatch.