### PR TITLE
target-version option kebab-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ to denote a significant space character.
 ```toml
 [tool.black]
 line-length = 88
-target_version = ['py37']
+target-version = ['py37']
 include = '\.pyi?$'
 exclude = '''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 
 [tool.black]
 line-length = 88
-target_version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
In the TOML file the `--target-version` CLI option is represented in snake case instead of kebab case.

This is only a style change, Black works with both snake and kebab cases anyway.
